### PR TITLE
Add API key auth and request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,16 @@ VITE_ENV=production
 NODE_ENV=development
 PORT=3002
 ALLOWED_ORIGINS=https://dev.xml.lojasrealce.shop
+API_KEY=dev-secret
 
 # Produção
 NODE_ENV=production
 PORT=3001
 ALLOWED_ORIGINS=https://xml.lojasrealce.shop,https://www.xml.lojasrealce.shop
+API_KEY=prod-secret
 ```
+
+Todas as requisições para a API devem incluir o cabeçalho `x-api-key` com o valor definido em `API_KEY`.
 
 ### **Configuração PM2**
 

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,8 @@ Este é o servidor backend para o XML Importer, que fornece uma API REST para ge
 - **API REST**: Endpoints para CRUD de NFEs e produtos
 - **Upload de XML**: Processamento de arquivos XML de NF-e
 - **CORS Configurado**: Acesso remoto de outros PCs
-- **Segurança**: Helmet para proteção básica
+- **Segurança**: Helmet para proteção básica e chave de API
+- **Validação**: Schemas de entrada com express-validator
 
 ## 📋 Pré-requisitos
 
@@ -27,8 +28,9 @@ Este é o servidor backend para o XML Importer, que fornece uma API REST para ge
    ```bash
    # Copiar arquivo de exemplo
    copy env.example .env
-   
+
    # Editar .env com suas configurações
+   # Inclua uma API_KEY para habilitar autenticação simples
    ```
 
 3. **Iniciar servidor:**
@@ -75,6 +77,8 @@ http://[SEU_IP]:3001/api/status
 
 ### Status
 - `GET /api/status` - Status do servidor
+
+> Todos os endpoints exigem o cabeçalho `x-api-key` definido no `.env`.
 
 ## 🗄️ Estrutura do Banco de Dados
 
@@ -125,6 +129,7 @@ http://[SEU_IP]:3001/api/status
 - **CORS**: Configurado para permitir apenas origens específicas
 - **Helmet**: Headers de segurança básicos
 - **Validação**: Validação de entrada nos endpoints
+- **Autenticação**: Proteção por chave de API via header `x-api-key`
 - **Rate Limiting**: Pode ser adicionado se necessário
 
 ## 📝 Scripts Disponíveis

--- a/server/env.example
+++ b/server/env.example
@@ -6,6 +6,8 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000,http://192.168.1.100
 
 # Configurações de Segurança
 NODE_ENV=development
+# Chave de API para autenticação
+API_KEY=changeme
 
 # Configurações do Banco de Dados
-DB_PATH=./database.sqlite 
+DB_PATH=./database.sqlite

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,11 @@
+export const authMiddleware = (req, res, next) => {
+  const apiKey = process.env.API_KEY;
+  if (!apiKey) {
+    return next();
+  }
+  const headerKey = req.header('x-api-key');
+  if (headerKey && headerKey === apiKey) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+};

--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -1,0 +1,9 @@
+import { validationResult } from 'express-validator';
+
+export const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-validator": "^7.2.1",
         "helmet": "^7.1.0",
         "multer": "^1.4.5-lts.1"
       },
@@ -589,6 +590,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -911,6 +925,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1786,6 +1806,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,14 +9,15 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
     "better-sqlite3": "^11.9.1",
-    "multer": "^1.4.5-lts.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-validator": "^7.2.1",
     "helmet": "^7.1.0",
-    "dotenv": "^16.3.1"
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"
   }
-} 
+}

--- a/server/routes/nfeRoutes.js
+++ b/server/routes/nfeRoutes.js
@@ -1,12 +1,40 @@
 import express from 'express';
+import { body, param } from 'express-validator';
+import { validate } from '../middleware/validate.js';
 import { listNfes, getNfe, createNfe, updateNfeController, deleteNfeController } from '../controllers/nfeController.js';
 
 const router = express.Router();
 
 router.get('/', listNfes);
-router.get('/:id', getNfe);
-router.post('/', createNfe);
-router.put('/:id', updateNfeController);
-router.delete('/:id', deleteNfeController);
+router.get('/:id', [param('id').isString().notEmpty()], validate, getNfe);
+router.post('/', [
+  body('id').isString().notEmpty(),
+  body('data').optional().isString(),
+  body('numero').optional().isString(),
+  body('chaveNFE').optional().isString(),
+  body('fornecedor').optional().isString(),
+  body('valor').optional().isNumeric(),
+  body('itens').optional().isNumeric(),
+  body('produtos').optional().isArray(),
+  body('impostoEntrada').optional().isNumeric(),
+  body('xapuriMarkup').optional().isNumeric(),
+  body('epitaMarkup').optional().isNumeric(),
+  body('roundingType').optional().isString(),
+  body('valorFrete').optional().isNumeric(),
+  body('hiddenItems').optional().isArray(),
+  body('showHidden').optional().isBoolean()
+], validate, createNfe);
+router.put('/:id', [
+  param('id').isString().notEmpty(),
+  body('fornecedor').optional().isString(),
+  body('impostoEntrada').optional().isNumeric(),
+  body('xapuriMarkup').optional().isNumeric(),
+  body('epitaMarkup').optional().isNumeric(),
+  body('roundingType').optional().isString(),
+  body('valorFrete').optional().isNumeric(),
+  body('hiddenItems').optional().isArray(),
+  body('showHidden').optional().isBoolean()
+], validate, updateNfeController);
+router.delete('/:id', [param('id').isString().notEmpty()], validate, deleteNfeController);
 
 export default router;

--- a/server/routes/uploadRoutes.js
+++ b/server/routes/uploadRoutes.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import multer from 'multer';
+import { check } from 'express-validator';
+import { validate } from '../middleware/validate.js';
 import { uploadXml } from '../controllers/uploadController.js';
 
 const router = express.Router();
@@ -11,6 +13,25 @@ const upload = multer({
   }
 });
 
-router.post('/upload-xml', upload.single('xml'), uploadXml);
+router.post(
+  '/upload-xml',
+  upload.single('xml'),
+  [
+    check('xml').custom((value, { req }) => {
+      if (!req.file) {
+        throw new Error('Arquivo XML é obrigatório');
+      }
+      if (
+        req.file.mimetype !== 'text/xml' &&
+        !req.file.originalname.toLowerCase().endsWith('.xml')
+      ) {
+        throw new Error('Formato de arquivo inválido');
+      }
+      return true;
+    })
+  ],
+  validate,
+  uploadXml
+);
 
 export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ import uploadRoutes from './routes/uploadRoutes.js';
 import statusRoutes from './routes/statusRoutes.js';
 import debugRoutes from './routes/debugRoutes.js';
 import db, { DB_PATH } from './models/database.js';
+import { authMiddleware } from './middleware/auth.js';
 
 dotenv.config();
 
@@ -23,6 +24,7 @@ app.use(cors({
 }));
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+app.use(authMiddleware);
 
 // Rotas
 app.use('/api/nfes', nfeRoutes);


### PR DESCRIPTION
## Summary
- add express-validator schemas and middleware to validate API requests
- enforce optional API key authentication via reusable middleware
- document new API key configuration and request requirements

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac23bd3904832582f429094950ce6e