### PR TITLE
Add tests for API routes with auth simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ npm start            # Iniciar servidor
 npm run dev          # Modo desenvolvimento
 ```
 
+### **Testes**
+```bash
+cd server
+npm test
+```
+
+Os testes simulam autenticação utilizando o cabeçalho `x-api-key` para passar pelo `authMiddleware`.
+
 ### **Estrutura de Branches**
 ```bash
 main      # Produção (deploy automático)

--- a/server/routes/nfeRoutes.test.js
+++ b/server/routes/nfeRoutes.test.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import request from 'supertest';
 import { jest } from '@jest/globals';
+import { authMiddleware } from '../middleware/auth.js';
 
 await jest.unstable_mockModule('../models/nfeModel.js', () => ({
   getAllNfes: jest.fn(),
@@ -10,18 +11,34 @@ await jest.unstable_mockModule('../models/nfeModel.js', () => ({
   deleteNfe: jest.fn(),
 }));
 
-const { getAllNfes } = await import('../models/nfeModel.js');
+const { getAllNfes, getNfeById } = await import('../models/nfeModel.js');
 const nfeRoutes = (await import('./nfeRoutes.js')).default;
 
 const app = express();
 app.use(express.json());
+app.use(authMiddleware);
 app.use('/api/nfes', nfeRoutes);
+
+process.env.API_KEY = 'testkey';
 
 describe('GET /api/nfes', () => {
   it('should return list of NFEs', async () => {
     getAllNfes.mockReturnValue([{ id: '1' }]);
-    const res = await request(app).get('/api/nfes');
+    const res = await request(app)
+      .get('/api/nfes')
+      .set('x-api-key', 'testkey');
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ id: '1' }]);
+  });
+});
+
+describe('GET /api/nfes/:id', () => {
+  it('should return 404 when NFE is not found', async () => {
+    getNfeById.mockReturnValue(null);
+    const res = await request(app)
+      .get('/api/nfes/123')
+      .set('x-api-key', 'testkey');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'NFE não encontrada' });
   });
 });

--- a/server/routes/statusRoutes.test.js
+++ b/server/routes/statusRoutes.test.js
@@ -1,0 +1,21 @@
+import express from 'express';
+import request from 'supertest';
+import { authMiddleware } from '../middleware/auth.js';
+import statusRoutes from './statusRoutes.js';
+
+process.env.API_KEY = 'testkey';
+
+const app = express();
+app.use(authMiddleware);
+app.use('/api', statusRoutes);
+
+describe('GET /api/status', () => {
+  it('should return API status information', async () => {
+    const res = await request(app)
+      .get('/api/status')
+      .set('x-api-key', 'testkey');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('online');
+    expect(res.body).toHaveProperty('timestamp');
+  });
+});

--- a/server/routes/uploadRoutes.test.js
+++ b/server/routes/uploadRoutes.test.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import request from 'supertest';
+import { authMiddleware } from '../middleware/auth.js';
+import uploadRoutes from './uploadRoutes.js';
+
+process.env.API_KEY = 'testkey';
+
+const app = express();
+app.use(authMiddleware);
+app.use('/api', uploadRoutes);
+
+describe('POST /api/upload-xml', () => {
+  it('should upload XML file successfully', async () => {
+    const res = await request(app)
+      .post('/api/upload-xml')
+      .set('x-api-key', 'testkey')
+      .attach('xml', Buffer.from('<root></root>'), 'file.xml');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Arquivo recebido com sucesso');
+    expect(res.body.content).toContain('<root');
+  });
+
+  it('should return 400 when no file is provided', async () => {
+    const res = await request(app)
+      .post('/api/upload-xml')
+      .set('x-api-key', 'testkey');
+    expect(res.status).toBe(400);
+    expect(Array.isArray(res.body.errors)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- test upload and status routes with API key authentication
- cover nfeRoutes not-found scenario and auth middleware
- document how to run backend tests

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3e7a80e48325a960851a8d751833