### PR TITLE
Centralize environment configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,15 @@
+# Backend
+PORT=4005
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+NODE_ENV=development
+API_KEY=changeme
+DB_PATH=server/database.sqlite
+DEBUG_DB=false
+LOG_LEVEL=info
+
+# Frontend
+VITE_API_URL=http://localhost:4005/api
+VITE_APP_NAME=XML Importer (Dev)
+VITE_APP_VERSION=3.1.0
+VITE_ENV=development
+VITE_DEBUG=true

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,15 @@
+# Backend
+PORT=3001
+ALLOWED_ORIGINS=https://seu-dominio.com
+NODE_ENV=production
+API_KEY=changeme
+DB_PATH=server/database.sqlite
+DEBUG_DB=false
+LOG_LEVEL=info
+
+# Frontend
+VITE_API_URL=https://seu-dominio.com/api
+VITE_APP_NAME=XML Importer
+VITE_APP_VERSION=3.1.0
+VITE_ENV=production
+VITE_DEBUG=false

--- a/frontend/env.development
+++ b/frontend/env.development
@@ -1,4 +1,0 @@
-# Ambiente de Desenvolvimento
-VITE_API_URL=http://localhost:4005/api
-VITE_ENV=development
-VITE_APP_NAME=XML Importer (Dev)

--- a/frontend/env.production.example
+++ b/frontend/env.production.example
@@ -1,5 +1,0 @@
-# Configuração para Produção (Hostinger)
-# Copie este arquivo para .env.production e configure com seu domínio
-VITE_API_URL=https://seu-dominio.com/api
-VITE_APP_NAME=XML Importer
-VITE_APP_VERSION=3.1.0

--- a/frontend/src/components/FileUploadPDF.tsx
+++ b/frontend/src/components/FileUploadPDF.tsx
@@ -21,7 +21,8 @@ const FileUploadPDF: React.FC<FileUploadPDFProps> = ({ onItemsExtracted }) => {
       try {
         const formData = new FormData();
         formData.append('pedido', file);
-        const res = await axios.post('http://localhost:3001/api/importar-pedido', formData, {
+        const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+        const res = await axios.post(`${apiUrl}/importar-pedido`, formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         });
         if (res.data && res.data.itens) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,22 +1,7 @@
 import axios from 'axios';
 
-// Configuração para diferentes ambientes
-const getApiBaseUrl = () => {
-  // Verificar se está no domínio de desenvolvimento
-  if (window.location.hostname === 'dev.xml.lojasrealce.shop') {
-    return 'https://dev-api.xml.lojasrealce.shop/api';
-  }
-
-  // Se estiver em produção (Hostinger), usar API externa
-  if (import.meta.env.PROD) {
-    return import.meta.env.VITE_API_URL || 'https://api.xml.lojasrealce.shop/api';
-  }
-
-  // Se estiver em desenvolvimento local, usar local
-  return import.meta.env.VITE_API_URL || 'http://localhost:4005/api';
-};
-
-const API_BASE_URL = getApiBaseUrl();
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4005/api';
+const DEBUG = import.meta.env.VITE_DEBUG === 'true';
 
 const api = axios.create({
   baseURL: API_BASE_URL,
@@ -29,22 +14,30 @@ const api = axios.create({
 // Interceptor para logs
 api.interceptors.request.use(
   (config) => {
-    console.log(`🚀 API Request: ${config.method?.toUpperCase()} ${config.url}`);
+    if (DEBUG) {
+      console.log(`🚀 API Request: ${config.method?.toUpperCase()} ${config.url}`);
+    }
     return config;
   },
   (error) => {
-    console.error('❌ API Request Error:', error);
+    if (DEBUG) {
+      console.error('❌ API Request Error:', error);
+    }
     return Promise.reject(error);
   }
 );
 
 api.interceptors.response.use(
   (response) => {
-    console.log(`✅ API Response: ${response.status} ${response.config.url}`);
+    if (DEBUG) {
+      console.log(`✅ API Response: ${response.status} ${response.config.url}`);
+    }
     return response;
   },
   (error) => {
-    console.error('❌ API Response Error:', error.response?.data || error.message);
+    if (DEBUG) {
+      console.error('❌ API Response Error:', error.response?.data || error.message);
+    }
     return Promise.reject(error);
   }
 );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,10 +4,12 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
+  const envDir = path.resolve(__dirname, '..')
   // Carregar variáveis de ambiente baseado no modo
-  const env = loadEnv(mode, process.cwd(), '')
-  
+  const env = loadEnv(mode, envDir, '')
+
   return {
+    envDir,
     plugins: [react()],
     resolve: {
       alias: {

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..', '..');
+
+const nodeEnv = process.env.NODE_ENV || 'development';
+const envFile = path.join(rootDir, `.env.${nodeEnv}`);
+dotenv.config({ path: envFile });
+
+const config = {
+  env: nodeEnv,
+  port: parseInt(process.env.PORT, 10) || 3001,
+  allowedOrigins: process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',')
+    : ['http://localhost:5173'],
+  apiKey: process.env.API_KEY || '',
+  dbPath: path.resolve(rootDir, process.env.DB_PATH || 'server/database.sqlite'),
+  debugDb: process.env.DEBUG_DB === 'true',
+  logLevel: process.env.LOG_LEVEL || 'info',
+};
+
+export default config;

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,5 +1,7 @@
+import config from '../config/index.js';
+
 export const authMiddleware = (req, res, next) => {
-  const apiKey = process.env.API_KEY;
+  const apiKey = config.apiKey;
   if (!apiKey) {
     return next();
   }

--- a/server/models/database.js
+++ b/server/models/database.js
@@ -1,19 +1,15 @@
 import Database from 'better-sqlite3';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import config from '../config/index.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'database.sqlite');
-if (process.env.DEBUG_DB === 'true') {
+export const DB_PATH = config.dbPath;
+if (config.debugDb) {
   console.log('DB_OPEN', DB_PATH);
 }
 
-const db = new Database(DB_PATH, { verbose: process.env.DEBUG_DB === 'true' ? console.log : undefined });
+const db = new Database(DB_PATH, { verbose: config.debugDb ? console.log : undefined });
 
 // Logar colunas reais da tabela nfes em runtime para auditoria
-if (process.env.DEBUG_DB === 'true') {
+if (config.debugDb) {
   try {
     const cols = db.prepare('PRAGMA table_info(nfes)').all();
     console.log('NFES_COLUMNS', cols);

--- a/server/routes/nfeRoutes.test.js
+++ b/server/routes/nfeRoutes.test.js
@@ -2,6 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { jest } from '@jest/globals';
 import { authMiddleware } from '../middleware/auth.js';
+import config from '../config/index.js';
 
 await jest.unstable_mockModule('../models/nfeModel.js', () => ({
   getAllNfes: jest.fn(),
@@ -19,7 +20,7 @@ app.use(express.json());
 app.use(authMiddleware);
 app.use('/api/nfes', nfeRoutes);
 
-process.env.API_KEY = 'testkey';
+config.apiKey = 'testkey';
 
 describe('GET /api/nfes', () => {
   it('should return list of NFEs', async () => {

--- a/server/routes/statusRoutes.test.js
+++ b/server/routes/statusRoutes.test.js
@@ -2,8 +2,9 @@ import express from 'express';
 import request from 'supertest';
 import { authMiddleware } from '../middleware/auth.js';
 import statusRoutes from './statusRoutes.js';
+import config from '../config/index.js';
 
-process.env.API_KEY = 'testkey';
+config.apiKey = 'testkey';
 
 const app = express();
 app.use(authMiddleware);

--- a/server/routes/uploadRoutes.test.js
+++ b/server/routes/uploadRoutes.test.js
@@ -2,8 +2,9 @@ import express from 'express';
 import request from 'supertest';
 import { authMiddleware } from '../middleware/auth.js';
 import uploadRoutes from './uploadRoutes.js';
+import config from '../config/index.js';
 
-process.env.API_KEY = 'testkey';
+config.apiKey = 'testkey';
 
 const app = express();
 app.use(authMiddleware);

--- a/server/server-production.js
+++ b/server/server-production.js
@@ -2,18 +2,11 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import Database from 'better-sqlite3';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import multer from 'multer';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import config from './config/index.js';
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = config.port;
 
 // Middleware de segurança para produção
 app.use(
@@ -35,12 +28,7 @@ app.use(
 // CORS configurado para produção
 app.use(
   cors({
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'https://xml.lojasrealce.shop',
-      'https://www.xml.lojasrealce.shop',
-      'https://dev.xml.lojasrealce.shop',
-      'http://localhost:5173',
-    ],
+    origin: config.allowedOrigins,
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
@@ -59,7 +47,7 @@ const upload = multer({
 });
 
 // Inicializar banco de dados
-const dbPath = process.env.DB_PATH || path.join(__dirname, 'database.sqlite');
+const dbPath = config.dbPath;
 const db = new Database(dbPath, { verbose: console.log });
 
 // Criar tabelas se não existirem

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
-import dotenv from 'dotenv';
 
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './docs/swagger.js';
@@ -13,19 +12,16 @@ import debugRoutes from './routes/debugRoutes.js';
 import db, { DB_PATH } from './models/database.js';
 import { authMiddleware } from './middleware/auth.js';
 import logger from './utils/logger.js';
-
-dotenv.config();
+import config from './config/index.js';
 
 const app = express();
-const PORT = process.env.PORT || 4005;
+const PORT = config.port;
 
 // Middleware
 app.use(helmet());
 app.use(
   cors({
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'http://localhost:4000',
-    ],
+    origin: config.allowedOrigins,
     credentials: true,
   }),
 );
@@ -38,7 +34,7 @@ app.use(authMiddleware);
 app.use('/api/nfes', nfeRoutes);
 app.use('/api', uploadRoutes);
 app.use('/api', statusRoutes);
-if (process.env.DEBUG_DB === 'true') {
+if (config.debugDb) {
   app.use('/api', debugRoutes);
 }
 

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,7 +1,8 @@
 import { createLogger, format, transports } from 'winston';
+import config from '../config/index.js';
 
 const logger = createLogger({
-  level: process.env.LOG_LEVEL || 'info',
+  level: config.logLevel,
   format: format.combine(
     format.timestamp(),
     format.printf(({ level, message, timestamp }) => {


### PR DESCRIPTION
## Summary
- add root `.env` files for development and production
- introduce backend `config` module with dotenv
- read API URLs via Vite env in frontend

## Testing
- `cd server && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac471f3154832593403c7268b5542a