### PR TITLE
feat: add rate limiting and configurable cors

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -58,7 +58,13 @@ ifconfig
 ALLOWED_ORIGINS=http://localhost:5173,http://192.168.1.100:5173,http://192.168.1.101:5173
 ```
 
-### 4. Acessar de outros PCs:
+### 4. Configurar Rate Limit (opcional):
+```env
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=100
+```
+
+### 5. Acessar de outros PCs:
 ```
 http://[SEU_IP]:3001/api/status
 ```
@@ -126,11 +132,11 @@ http://[SEU_IP]:3001/api/status
 
 ## 🔒 Segurança
 
-- **CORS**: Configurado para permitir apenas origens específicas
+- **CORS**: Origens permitidas definidas via `ALLOWED_ORIGINS`
 - **Helmet**: Headers de segurança básicos
 - **Validação**: Validação de entrada nos endpoints
 - **Autenticação**: Proteção por chave de API via header `x-api-key`
-- **Rate Limiting**: Pode ser adicionado se necessário
+- **Rate Limiting**: Limita requisições por IP (`RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`)
 
 ## 📝 Scripts Disponíveis
 

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -20,6 +20,10 @@ const config = {
   dbPath: path.resolve(rootDir, process.env.DB_PATH || 'server/database.sqlite'),
   debugDb: process.env.DEBUG_DB === 'true',
   logLevel: process.env.LOG_LEVEL || 'info',
+  rateLimit: {
+    windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000,
+    max: parseInt(process.env.RATE_LIMIT_MAX, 10) || 100,
+  },
 };
 
 export default config;

--- a/server/docs/swagger.js
+++ b/server/docs/swagger.js
@@ -6,7 +6,8 @@ const options = {
     info: {
       title: 'XML Importer API',
       version: '1.0.0',
-      description: 'Documentação da API do XML Importer',
+      description:
+        'Documentação da API do XML Importer. Acesso restrito às origens definidas e limitado por IP.',
     },
     servers: [
       {

--- a/server/env.example
+++ b/server/env.example
@@ -9,5 +9,9 @@ NODE_ENV=development
 # Chave de API para autenticação
 API_KEY=changeme
 
+# Configurações de Rate Limit
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=100
+
 # Configurações do Banco de Dados
 DB_PATH=./database.sqlite

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^6.11.2",
         "express-validator": "^7.2.1",
         "helmet": "^7.1.0",
         "knex": "^3.1.0",
@@ -3576,6 +3577,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express-validator": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.11.2",
     "express-validator": "^7.2.1",
     "helmet": "^7.1.0",
     "knex": "^3.1.0",
@@ -26,12 +27,12 @@
     "winston": "^3.17.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.9.0",
+    "eslint": "^9.9.0",
     "jest": "^29.7.0",
     "nodemon": "^3.0.2",
+    "prettier": "^3.4.2",
     "supertest": "^6.3.4",
-    "eslint": "^9.9.0",
-    "@eslint/js": "^9.9.0",
-    "typescript-eslint": "^8.0.1",
-    "prettier": "^3.4.2"
+    "typescript-eslint": "^8.0.1"
   }
 }

--- a/server/rateLimit.test.js
+++ b/server/rateLimit.test.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import request from 'supertest';
+import rateLimit from 'express-rate-limit';
+
+const app = express();
+const limiter = rateLimit({ windowMs: 1000, max: 2 });
+app.use(limiter);
+app.get('/test', (req, res) => {
+  res.status(200).json({ ok: true });
+});
+
+describe('Rate limiter', () => {
+  it('blocks requests exceeding the limit', async () => {
+    await request(app).get('/test');
+    await request(app).get('/test');
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(429);
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './docs/swagger.js';
@@ -19,6 +20,13 @@ const PORT = config.port;
 
 // Middleware
 app.use(helmet());
+const limiter = rateLimit({
+  windowMs: config.rateLimit.windowMs,
+  max: config.rateLimit.max,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use(limiter);
 app.use(
   cors({
     origin: config.allowedOrigins,


### PR DESCRIPTION
## Summary
- limit repeated requests per IP using express-rate-limit
- allow CORS origins from environment variables
- document new CORS and rate-limit restrictions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4de8667c832589050aade962a3cc