### PR TITLE
chore: add CI workflow for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,82 @@ on:
   pull_request:
 
 jobs:
-  test:
+  backend:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        project: [server, frontend]
+    defaults:
+      run:
+        working-directory: server
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
-          cache-dependency-path: ${{ matrix.project }}/package-lock.json
+          cache-dependency-path: server/package-lock.json
       - name: Install dependencies
-        working-directory: ./${{ matrix.project }}
         run: npm ci
       - name: Run lint
-        working-directory: ./${{ matrix.project }}
         run: npm run lint
       - name: Run tests
-        working-directory: ./${{ matrix.project }}
         run: npm test
+      - name: Build backend
+        run: |
+          npm run build --if-present
+          npm pack
+      - name: Upload backend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend
+          path: server/*.tgz
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint
+      - name: Run tests
+        run: npm test
+      - name: Build frontend
+        run: npm run build
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend
+          path: frontend/dist
+
+  deploy:
+    needs:
+      - backend
+      - frontend
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend
+          path: backend
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend
+          path: frontend
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            echo "Implementar comandos de deploy aqui"


### PR DESCRIPTION
## Summary
- add CI workflow for backend and frontend
- install, lint, test each project
- build and upload artifacts for backend and frontend
- optional deploy job using SSH

## Testing
- `npm test` (server)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ac502261c08325a176fc0f6c6784b8