### PR TITLE
Handle errors with next middleware

### DIFF
--- a/server/controllers/errorHandler.test.js
+++ b/server/controllers/errorHandler.test.js
@@ -10,7 +10,7 @@ const app = express();
 app.get('/erro', faultyController);
 
 // Middleware de tratamento de erros semelhante ao usado no servidor
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err, req, res, next) => {
   res.status(500).json({ error: 'Algo deu errado!' });
 });

--- a/server/controllers/errorHandler.test.js
+++ b/server/controllers/errorHandler.test.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import request from 'supertest';
+
+// Controller que força um erro ao chamar next com uma exceção
+const faultyController = (req, res, next) => {
+  next(new Error('Erro forçado'));
+};
+
+const app = express();
+app.get('/erro', faultyController);
+
+// Middleware de tratamento de erros semelhante ao usado no servidor
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  res.status(500).json({ error: 'Algo deu errado!' });
+});
+
+describe('Middleware de erro', () => {
+  it('retorna status 500 quando ocorre um erro', async () => {
+    const res = await request(app).get('/erro');
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('error', 'Algo deu errado!');
+  });
+});
+

--- a/server/server.js
+++ b/server/server.js
@@ -47,7 +47,8 @@ if (config.debugDb) {
 }
 
 // Middleware de tratamento de erros
-app.use((err, req, res) => {
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
   logger.error(err.stack);
   res.status(500).json({ error: 'Algo deu errado!' });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -47,7 +47,7 @@ if (config.debugDb) {
 }
 
 // Middleware de tratamento de erros
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err, req, res, next) => {
   logger.error(err.stack);
   res.status(500).json({ error: 'Algo deu errado!' });


### PR DESCRIPTION
## Summary
- ensure server error handler uses Express' four-argument signature
- add regression test for 500 response when controller forwards error

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac56b9de008325996f4fd0815a1863