### PR TITLE
Parse NFE XML uploads and persist to database

### DIFF
--- a/server/__tests__/uploadRoutes.test.js
+++ b/server/__tests__/uploadRoutes.test.js
@@ -1,8 +1,15 @@
 import express from 'express';
 import request from 'supertest';
+import { jest } from '@jest/globals';
 import { authMiddleware } from '../middleware/auth.js';
-import uploadRoutes from '../routes/uploadRoutes.js';
 import config from '../config/index.js';
+
+await jest.unstable_mockModule('../models/nfeModel.js', () => ({
+  saveNfe: jest.fn(),
+}));
+
+const { saveNfe } = await import('../models/nfeModel.js');
+const uploadRoutes = (await import('../routes/uploadRoutes.js')).default;
 
 config.apiKey = 'testkey';
 
@@ -12,13 +19,45 @@ app.use('/api', uploadRoutes);
 
 describe('POST /api/upload-xml', () => {
   it('should upload XML file successfully', async () => {
+    saveNfe.mockReturnValue('123');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <NFe>
+      <infNFe Id="NFe123">
+        <ide>
+          <nNF>1</nNF>
+          <dhEmi>2024-01-01T00:00:00-03:00</dhEmi>
+        </ide>
+        <emit>
+          <xNome>Fornecedor Teste</xNome>
+        </emit>
+        <det nItem="1">
+          <prod>
+            <cProd>001</cProd>
+            <xProd>Produto Teste</xProd>
+            <NCM>1234</NCM>
+            <CFOP>5102</CFOP>
+            <uCom>UN</uCom>
+            <qCom>1</qCom>
+            <vUnCom>10.00</vUnCom>
+            <vProd>10.00</vProd>
+          </prod>
+        </det>
+        <total>
+          <ICMSTot>
+            <vNF>10.00</vNF>
+          </ICMSTot>
+        </total>
+      </infNFe>
+    </NFe>`;
+
     const res = await request(app)
       .post('/api/upload-xml')
       .set('x-api-key', 'testkey')
-      .attach('xml', Buffer.from('<root></root>'), 'file.xml');
+      .attach('xml', Buffer.from(xml), 'file.xml');
     expect(res.status).toBe(200);
-    expect(res.body.message).toBe('Arquivo recebido com sucesso');
-    expect(res.body.content).toContain('<root');
+    expect(res.body.message).toBe('NFE salva com sucesso');
+    expect(res.body.id).toBe('123');
   });
 
   it('should return 400 when no file is provided', async () => {

--- a/server/controllers/uploadController.js
+++ b/server/controllers/uploadController.js
@@ -1,19 +1,57 @@
+import { parseStringPromise } from 'xml2js';
+import { saveNfe } from '../models/nfeModel.js';
 import logger from '../utils/logger.js';
 
-export const uploadXml = (req, res) => {
+export const uploadXml = async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'Nenhum arquivo enviado' });
     }
 
     const xmlContent = req.file.buffer.toString('utf-8');
-    res.json({
-      message: 'Arquivo recebido com sucesso',
-      content: xmlContent.substring(0, 500) + '...'
+    const parsed = await parseStringPromise(xmlContent, { explicitArray: false });
+
+    const infNFe =
+      parsed?.nfeProc?.NFe?.infNFe || parsed?.NFe?.infNFe || parsed?.infNFe;
+    if (!infNFe) {
+      return res.status(400).json({ error: 'Estrutura de NFE inválida' });
+    }
+
+    const chave = (infNFe.$?.Id || '').replace(/^NFe/, '');
+    const detArray = Array.isArray(infNFe.det)
+      ? infNFe.det
+      : [infNFe.det];
+
+    const produtos = detArray.map((det) => {
+      const p = det.prod;
+      return {
+        codigo: p.cProd,
+        descricao: p.xProd,
+        ncm: p.NCM,
+        cfop: p.CFOP,
+        unidade: p.uCom,
+        quantidade: Number(p.qCom),
+        valorUnitario: Number(p.vUnCom),
+        valorTotal: Number(p.vProd),
+      };
     });
+
+    const nfeData = {
+      id: chave || infNFe.ide?.nNF,
+      data: infNFe.ide?.dhEmi || infNFe.ide?.dEmi,
+      numero: infNFe.ide?.nNF,
+      chaveNFE: chave,
+      fornecedor: infNFe.emit?.xNome,
+      valor: Number(infNFe.total?.ICMSTot?.vNF || 0),
+      itens: produtos.length,
+      produtos,
+    };
+
+    const id = saveNfe(nfeData);
+    res.json({ message: 'NFE salva com sucesso', id });
   } catch (error) {
     logger.error(`Erro no upload: ${error}`);
-    res.status(500).json({ error: 'Erro interno do servidor' });
+    res.status(500).json({ error: error.message || 'Erro interno do servidor' });
   }
 };
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "multer": "^1.4.5-lts.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -6412,6 +6413,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -7512,6 +7519,28 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "multer": "^1.4.5-lts.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Summary
- parse uploaded XML to extract NFE and product data
- save parsed data using existing NFE model
- test upload route to ensure persistence is triggered

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b81e8fc83258ed2463775c88095