### PR TITLE
fix: handle thousand separators in parseNumber

### DIFF
--- a/frontend/src/utils/nfeParser.ts
+++ b/frontend/src/utils/nfeParser.ts
@@ -55,7 +55,7 @@ export const parseNFeXML = (xmlText: string): Product[] => {
 
   const parseNumber = (text: string) => {
     if (!text) return 0;
-    const cleanText = text.replace(/[^\d,.-]/g, '').replace(',', '.');
+    const cleanText = text.replace(/\./g, '').replace(',', '.');
     const number = parseFloat(cleanText);
     return isNaN(number) ? 0 : number;
   };


### PR DESCRIPTION
## Summary
- ensure nfeParser numeric parser handles thousand separators before decimal conversion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad27a0776483258b65e895916da289