### PR TITLE
refactor: use format helpers

### DIFF
--- a/frontend/src/components/product-preview/types/column.ts
+++ b/frontend/src/components/product-preview/types/column.ts
@@ -1,4 +1,5 @@
 import { Product } from '../../../types/nfe';
+import { formatCurrency, formatNumber } from '@/utils/formatters';
 
 export interface Column {
   id: string;
@@ -101,51 +102,51 @@ export const getDefaultColumns = (): Column[] => [
     width: 'w-fit',
     minWidth: 80,
     order: 10,
-    format: (value: number) => value.toLocaleString()
+    format: (value: number) => formatNumber(value)
   },
-  { 
-    id: 'unitPrice', 
+  {
+    id: 'unitPrice',
     header: 'Custo Bruto', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 11,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    format: (value: number) => formatCurrency(value)
   },
-  { 
-    id: 'unitPriceWithDiscount', 
+  {
+    id: 'unitPriceWithDiscount',
     header: 'Custo c/ desconto', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 12,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => {
       const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
       return product.unitPrice - unitDiscount;
     }
   },
-  { 
-    id: 'totalPrice', 
+  {
+    id: 'totalPrice',
     header: 'Total', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 13,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    format: (value: number) => formatCurrency(value)
   },
-  { 
-    id: 'netPrice', 
+  {
+    id: 'netPrice',
     header: 'Custo Líquido', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 14,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => {
       const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
       const custoComDesconto = product.unitPrice - unitDiscount;
@@ -162,7 +163,7 @@ export const getDefaultColumns = (): Column[] => [
     width: 'w-fit',
     minWidth: 112,
     order: 14.5,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => product.freteProporcional ?? 0
   },
   {
@@ -173,39 +174,39 @@ export const getDefaultColumns = (): Column[] => [
     width: 'w-fit',
     minWidth: 112,
     order: 14.6,
-    format: (value: number) => value?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }) || '',
+    format: (value: number) => (value != null ? formatCurrency(value) : ''),
     getValue: (product: Product) => product.custoExtra ?? 0
   },
-  { 
-    id: 'unitDiscount', 
+  {
+    id: 'unitDiscount',
     header: 'Desc. Un.', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 15,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }),
+    format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => product.quantity > 0 ? product.discount / product.quantity : 0
   },
-  { 
-    id: 'xapuriPrice', 
+  {
+    id: 'xapuriPrice',
     header: 'Preço Xap.', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 16,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    format: (value: number) => formatCurrency(value)
   },
-  { 
-    id: 'epitaPrice', 
+  {
+    id: 'epitaPrice',
     header: 'Preço Epit.', 
     initiallyVisible: true, 
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 17,
-    format: (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+    format: (value: number) => formatCurrency(value)
   },
   {
     id: 'descricao_complementar',

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
 import { cn } from "@/lib/utils"
+import { formatNumber } from "@/utils/formatters"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -238,7 +239,7 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {formatNumber(item.value as number)}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- use formatting utilities in product columns
- centralize chart tooltip number formatting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad28a1cd408325a52fe14d28d57bff