### PR TITLE
test: add API route tests

### DIFF
--- a/server/__tests__/uploadRoutes.test.js
+++ b/server/__tests__/uploadRoutes.test.js
@@ -4,13 +4,16 @@ import { jest } from '@jest/globals';
 import { authMiddleware } from '../middleware/auth.js';
 import config from '../config/index.js';
 
-process.env.REDIS_HOST = 'redis';
-
 await jest.unstable_mockModule('../queues/nfeQueue.js', () => ({
   default: { add: jest.fn().mockResolvedValue({ id: 'job123' }) },
 }));
 
+await jest.unstable_mockModule('../models/nfeModel.js', () => ({
+  saveNfe: jest.fn(),
+}));
+
 const { default: nfeQueue } = await import('../queues/nfeQueue.js');
+const { saveNfe } = await import('../models/nfeModel.js');
 const uploadRoutes = (await import('../routes/uploadRoutes.js')).default;
 
 config.apiKey = 'testkey';
@@ -19,9 +22,7 @@ const app = express();
 app.use(authMiddleware);
 app.use('/api', uploadRoutes);
 
-describe('POST /api/upload-xml', () => {
-  it('should enqueue XML file successfully', async () => {
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
     <NFe>
       <infNFe Id="NFe123">
         <ide>
@@ -51,6 +52,13 @@ describe('POST /api/upload-xml', () => {
       </infNFe>
     </NFe>`;
 
+describe('POST /api/upload-xml', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should enqueue XML file successfully', async () => {
+    process.env.REDIS_HOST = 'redis';
     const res = await request(app)
       .post('/api/upload-xml')
       .set('x-api-key', 'testkey')
@@ -58,10 +66,24 @@ describe('POST /api/upload-xml', () => {
     expect(res.status).toBe(202);
     expect(res.body.id).toBe('job123');
     expect(nfeQueue.add).toHaveBeenCalledTimes(1);
+    expect(saveNfe).not.toHaveBeenCalled();
+  });
+
+  it('should process XML when no queue is configured', async () => {
+    delete process.env.REDIS_HOST;
+    saveNfe.mockReturnValue('123');
+    const res = await request(app)
+      .post('/api/upload-xml')
+      .set('x-api-key', 'testkey')
+      .attach('xml', Buffer.from(xml), 'file.xml');
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe('123');
+    expect(saveNfe).toHaveBeenCalledTimes(1);
+    expect(nfeQueue.add).not.toHaveBeenCalled();
   });
 
   it('should return 400 when no file is provided', async () => {
-    nfeQueue.add.mockClear();
+    delete process.env.REDIS_HOST;
     const res = await request(app)
       .post('/api/upload-xml')
       .set('x-api-key', 'testkey');


### PR DESCRIPTION
## Summary
- add supertest tests for creating and fetching NFEs
- cover upload endpoint for queued and immediate processing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3506c1448325b1115c83da38826b