### PR TITLE
Add Playwright e2e test for NFE product view

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xml-4",
   "private": true,
   "scripts": {
-    "test:e2e": "playwright test"
+    "test:e2e": "TEST_BASE_URL=http://localhost:4005 playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0"

--- a/tests/e2e/upload.spec.ts
+++ b/tests/e2e/upload.spec.ts
@@ -36,7 +36,7 @@ const sampleXml = `<?xml version="1.0" encoding="UTF-8"?>
   </infNFe>
 </NFe>`;
 
-test('upload XML and list NFEs', async ({ request }) => {
+test('Upload de NFE e visualização de produtos', async ({ request }) => {
   const uploadResponse = await request.post(`${baseURL}/api/upload-xml`, {
     headers: {
       ...(apiKey ? { 'x-api-key': apiKey } : {}),
@@ -51,18 +51,18 @@ test('upload XML and list NFEs', async ({ request }) => {
   });
 
   expect(uploadResponse.ok()).toBeTruthy();
-  const body = await uploadResponse.json();
-  const id = body.id;
+  const { id } = await uploadResponse.json();
   expect(id).toBeTruthy();
 
-  const listResponse = await request.get(`${baseURL}/api/nfes`, {
+  const nfeResponse = await request.get(`${baseURL}/api/nfes/${id}`, {
     headers: {
       ...(apiKey ? { 'x-api-key': apiKey } : {}),
     },
   });
 
-  expect(listResponse.ok()).toBeTruthy();
-  const nfes = await listResponse.json();
-  const hasUploaded = Array.isArray(nfes) && nfes.some((nfe: any) => nfe.id === id);
-  expect(hasUploaded).toBeTruthy();
+  expect(nfeResponse.ok()).toBeTruthy();
+  const nfe = await nfeResponse.json();
+  expect(Array.isArray(nfe.produtos)).toBeTruthy();
+  const hasProduct = nfe.produtos.some((p: any) => p.descricao === 'Produto Teste');
+  expect(hasProduct).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- configure `test:e2e` script to target the development server
- cover upload flow with product display in Playwright tests

## Testing
- `npm --prefix server run migrate` *(fails: sh: 1: knex: not found)*
- `npm run test:e2e` *(fails: connect ECONNREFUSED ::1:4005)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4c88ce8083258a7f681f79535503