### PR TITLE
feat: add discount and net price fields

### DIFF
--- a/server/migrations/20240504120000_create_tables.cjs
+++ b/server/migrations/20240504120000_create_tables.cjs
@@ -43,6 +43,8 @@ exports.up = async function(knex) {
     table.text('descricao_complementar');
     table.float('custoExtra').defaultTo(0);
     table.float('freteProporcional').defaultTo(0);
+    table.float('discount').defaultTo(0);
+    table.float('netPrice').defaultTo(0);
     table.foreign('nfeId').references('id').inTable('nfes').onDelete('CASCADE');
   });
 

--- a/server/models/nfeModel.js
+++ b/server/models/nfeModel.js
@@ -5,9 +5,9 @@ export const getAllNfes = () => {
     SELECT
       n.*,
       COUNT(p.id) as produtosCount,
-      SUM(p.valorTotal) as valorTotal,
-      SUM(p.discount) as discountTotal,
-      SUM(p.netPrice) as netPriceTotal
+      COALESCE(SUM(p.valorTotal), 0) as valorTotal,
+      COALESCE(SUM(p.discount), 0) as discountTotal,
+      COALESCE(SUM(p.netPrice), 0) as netPriceTotal
     FROM nfes n
     LEFT JOIN produtos p ON n.id = p.nfeId
     GROUP BY n.id
@@ -43,7 +43,7 @@ export const getNfeById = (id) => {
       valorUnitario, valorTotal, baseCalculoICMS, valorICMS, aliquotaICMS,
       baseCalculoIPI, valorIPI, aliquotaIPI, ean, reference, brand,
       imageUrl, descricao_complementar, custoExtra, freteProporcional,
-      discount, netPrice
+      COALESCE(discount, 0) as discount, COALESCE(netPrice, 0) as netPrice
     FROM produtos
     WHERE nfeId = ?
   `);
@@ -144,10 +144,10 @@ export const saveNfe = ({
           produto.brand,
           produto.imageUrl,
           produto.descricao_complementar,
-          produto.custoExtra || 0,
-          produto.freteProporcional || 0,
-          produto.discount || 0,
-          produto.netPrice || 0,
+          produto.custoExtra ?? 0,
+          produto.freteProporcional ?? 0,
+          produto.discount ?? 0,
+          produto.netPrice ?? 0,
         );
       });
     }

--- a/server/models/nfeModel.js
+++ b/server/models/nfeModel.js
@@ -5,7 +5,9 @@ export const getAllNfes = () => {
     SELECT
       n.*,
       COUNT(p.id) as produtosCount,
-      SUM(p.valorTotal) as valorTotal
+      SUM(p.valorTotal) as valorTotal,
+      SUM(p.discount) as discountTotal,
+      SUM(p.netPrice) as netPriceTotal
     FROM nfes n
     LEFT JOIN produtos p ON n.id = p.nfeId
     GROUP BY n.id
@@ -35,7 +37,16 @@ export const getNfeById = (id) => {
     return null;
   }
 
-  const produtosStmt = db.prepare('SELECT * FROM produtos WHERE nfeId = ?');
+  const produtosStmt = db.prepare(`
+    SELECT
+      id, nfeId, codigo, descricao, ncm, cfop, unidade, quantidade,
+      valorUnitario, valorTotal, baseCalculoICMS, valorICMS, aliquotaICMS,
+      baseCalculoIPI, valorIPI, aliquotaIPI, ean, reference, brand,
+      imageUrl, descricao_complementar, custoExtra, freteProporcional,
+      discount, netPrice
+    FROM produtos
+    WHERE nfeId = ?
+  `);
   const produtos = produtosStmt.all(id);
 
   let hiddenItems = [];
@@ -83,8 +94,9 @@ export const saveNfe = ({
       nfeId, codigo, descricao, ncm, cfop, unidade, quantidade,
       valorUnitario, valorTotal, baseCalculoICMS, valorICMS, aliquotaICMS,
       baseCalculoIPI, valorIPI, aliquotaIPI, ean, reference, brand,
-      imageUrl, descricao_complementar, custoExtra, freteProporcional
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      imageUrl, descricao_complementar, custoExtra, freteProporcional,
+      discount, netPrice
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const deleteProdutos = db.prepare('DELETE FROM produtos WHERE nfeId = ?');
@@ -134,6 +146,8 @@ export const saveNfe = ({
           produto.descricao_complementar,
           produto.custoExtra || 0,
           produto.freteProporcional || 0,
+          produto.discount || 0,
+          produto.netPrice || 0,
         );
       });
     }


### PR DESCRIPTION
## Summary
- add discount and net price columns to produtos table
- persist new fields in nfe model insert and queries
- include totals for discount and net price when listing NFes

## Testing
- `npm --prefix server run migrate`
- `npm --prefix server test`
- `npm --prefix server run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad68713db08325a687ac5e7f003ff8