### PR TITLE
feat: add API key header

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,6 +9,7 @@ LOG_LEVEL=info
 
 # Frontend
 VITE_API_URL=http://localhost:4005/api
+VITE_API_KEY=changeme
 VITE_APP_NAME=XML Importer (Dev)
 VITE_APP_VERSION=3.1.0
 VITE_ENV=development

--- a/.env.production
+++ b/.env.production
@@ -9,6 +9,7 @@ LOG_LEVEL=info
 
 # Frontend
 VITE_API_URL=https://seu-dominio.com/api
+VITE_API_KEY=changeme
 VITE_APP_NAME=XML Importer
 VITE_APP_VERSION=3.1.0
 VITE_ENV=production

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=https://82.29.58.242:3001/api
+VITE_API_KEY=changeme

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,6 +8,7 @@ const api = axios.create({
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',
+    'x-api-key': import.meta.env.VITE_API_KEY ?? '',
   },
 });
 


### PR DESCRIPTION
## Summary
- add x-api-key header to axios client
- define VITE_API_KEY in environment files

## Testing
- `npm ci`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad83e34b908325bc7e6daf1d19b7cc