### PR TITLE
chore: update API URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,7 +8,7 @@ DEBUG_DB=false
 LOG_LEVEL=info
 
 # Frontend
-VITE_API_URL=http://localhost:4005/api
+VITE_API_URL=https://seu-dominio.com/api
 VITE_API_KEY=changeme
 VITE_APP_NAME=XML Importer (Dev)
 VITE_APP_VERSION=3.1.0

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
-VITE_API_URL=https://82.29.58.242:3001/api
+VITE_API_URL=https://seu-dominio.com/api
 VITE_API_KEY=changeme


### PR DESCRIPTION
## Summary
- point frontend production build to new API domain
- set development API URL to new domain

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad901abc00832597439fb59d26e99e