### PR TITLE
Document frontend location and ignore legacy lixo folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 temp/
 frontend-backup-*/
 backup-antes-simplificacao/
+# Legacy discarded resources
 lixo/
 
 # Playwright

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@
 - **Servidor**: Hostinger VPS (Ubuntu)
 
 ### **Estrutura do Projeto**
+
+O frontend oficial reside exclusivamente na pasta `frontend/`.
+
 ```
 xml-4/
 ├── frontend/                    # Frontend React


### PR DESCRIPTION
## Summary
- Ensure legacy `lixo/` directory stays ignored
- Clarify in README that the official frontend lives in `frontend/`

## Testing
- `npm test` (server) *(fails: getNfeByChave missing)*
- `npm test -- --run` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68adbaac8ab083259ed0f71d8a0f403c