### PR TITLE
refactor: unify NFE product field names

### DIFF
--- a/frontend/src/__tests__/ProductTable.test.tsx
+++ b/frontend/src/__tests__/ProductTable.test.tsx
@@ -34,7 +34,7 @@ describe('ProductTable', () => {
   });
 
   const columns = getDefaultColumns().filter((c) =>
-    ['code', 'name', 'quantity', 'unitPrice', 'totalPrice'].includes(c.id)
+    ['codigo', 'descricao', 'quantidade', 'valorUnitario', 'valorTotal'].includes(c.id)
   );
   const visibleColumns = new Set(columns.map((c) => c.id));
 
@@ -56,13 +56,13 @@ describe('ProductTable', () => {
       aliquotaIPI: 0,
       xapuriPrice: 0,
       epitaPrice: 0,
-      code: '001',
-      name: 'Produto A',
-      totalPrice: 20,
+      ean: undefined,
+      reference: undefined,
+      brand: undefined,
       netPrice: 20,
       discount: 0,
-      quantity: 2,
-      unitPrice: 10,
+      imageUrl: undefined,
+      tags: undefined,
       salePrice: 0
     } as any,
     {
@@ -82,13 +82,13 @@ describe('ProductTable', () => {
       aliquotaIPI: 0,
       xapuriPrice: 0,
       epitaPrice: 0,
-      code: '002',
-      name: 'Produto B',
-      totalPrice: 5,
+      ean: undefined,
+      reference: undefined,
+      brand: undefined,
       netPrice: 5,
       discount: 0,
-      quantity: 1,
-      unitPrice: 5,
+      imageUrl: undefined,
+      tags: undefined,
       salePrice: 0
     } as any
   ];

--- a/frontend/src/components/product-preview/ExportOptions.tsx
+++ b/frontend/src/components/product-preview/ExportOptions.tsx
@@ -45,9 +45,9 @@ export const ExportOptions: React.FC<ExportOptionsProps> = ({
   onClose 
 }) => {
   const [exportFields, setExportFields] = useState<ExportField[]>([
-    { id: 'code', label: 'Código', checked: true },
+    { id: 'codigo', label: 'Código', checked: true },
     { id: 'ean', label: 'EAN', checked: true },
-    { id: 'name', label: 'Descrição', checked: true },
+    { id: 'descricao', label: 'Descrição', checked: true },
     { id: 'ncm', label: 'NCM', checked: true },
     { id: 'cfop', label: 'CFOP', checked: true },
     { id: 'unidade', label: 'Unidade', checked: true },
@@ -205,14 +205,14 @@ export const ExportOptions: React.FC<ExportOptionsProps> = ({
   const exportToDataSystemFormat = () => {
     // Formato específico para importação no DataSystem
     const dataSystemRows = products.map(product => ({
-      codigo: product.code,
+      codigo: product.codigo,
       ean: product.ean,
-      descricao: product.name,
+      descricao: product.descricao,
       ncm: product.ncm,
       preco_custo: product.netPrice,
       preco_venda: product.salePrice,
-      estoque: product.quantity,
-      unidade: product.uom,
+      estoque: product.quantidade,
+      unidade: product.unidade,
       marca: product.brand || brandName,
       referencia: product.reference || '',
       cor: product.color || '',

--- a/frontend/src/components/product-preview/ProductPreview.tsx
+++ b/frontend/src/components/product-preview/ProductPreview.tsx
@@ -48,7 +48,7 @@ const ProductPreview: React.FC<ProductPreviewProps> = ({
   const [valorFrete, setValorFrete] = useState<number>(0);
 
   // Calculate suggested markups
-  const totalBruto = products.reduce((sum, p) => sum + p.totalPrice, 0);
+  const totalBruto = products.reduce((sum, p) => sum + p.valorTotal, 0);
   const totalLiquido = products.reduce((sum, p) => sum + p.netPrice, 0);
   
   // Markup sugerido para Xapuri (ajustando para custo líquido)
@@ -118,7 +118,7 @@ const ProductPreview: React.FC<ProductPreviewProps> = ({
   };
 
   const handleImageSearch = async (index: number, product: Product) => {
-    const searchTerms = `${product.ean} ${product.code} ${product.name}`;
+    const searchTerms = `${product.ean} ${product.codigo} ${product.descricao}`;
     window.open(`https://www.google.com/search?q=${encodeURIComponent(searchTerms)}&tbm=isch`, '_blank');
   };
 
@@ -262,7 +262,7 @@ const ProductPreview: React.FC<ProductPreviewProps> = ({
           isOpen={isImageModalOpen}
           onClose={() => setIsImageModalOpen(false)}
           imageUrl={selectedImageProduct?.imageUrl || ''}
-          productName={selectedImageProduct?.name || ''}
+          productName={selectedImageProduct?.descricao || ''}
           productEan={selectedImageProduct?.ean || ''}
           onSearchNew={() => {
             if (selectedImageProduct) {

--- a/frontend/src/components/product-preview/ProductTable.tsx
+++ b/frontend/src/components/product-preview/ProductTable.tsx
@@ -93,7 +93,7 @@ const CellContent: React.FC<{
       if (
         column.id.toLowerCase().includes('price') ||
         column.id.toLowerCase().includes('valor') ||
-        column.id === 'unitPrice' ||
+        column.id === 'valorUnitario' ||
         column.id === 'netPrice'
       ) {
         return 'moeda';
@@ -109,7 +109,7 @@ const CellContent: React.FC<{
       formatacao={getFormatacao()}
       className={cn(
         'w-full flex items-center justify-center',
-        column.id === 'name' && 'whitespace-normal text-center',
+        column.id === 'descricao' && 'whitespace-normal text-center',
       )}
     />
   );
@@ -416,12 +416,12 @@ export const ProductTable: React.FC<ProductTableProps> = ({
       if (
         column.id.toLowerCase().includes('price') ||
         column.id.toLowerCase().includes('discount') ||
-        column.id === 'unitPrice' ||
+        column.id === 'valorUnitario' ||
         column.id === 'netPrice'
       ) {
         return formatNumberForCopy(value, 2);
       }
-      if (column.id === 'quantity') {
+      if (column.id === 'quantidade') {
         return formatNumberForCopy(value, 4);
       }
     }
@@ -486,7 +486,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
   // Gerar ID estável compatível com ProductPreview
   const getId = (p: Product, index: number): string => {
     if (p.ean && p.ean.length > 0) return String(p.ean);
-    if (p.code && p.code.length > 0) return `cod:${p.code}:${index}`;
+    if (p.codigo && p.codigo.length > 0) return `cod:${p.codigo}:${index}`;
     if (p.reference) return `ref:${p.reference}:${index}`;
     return `idx:${index}`;
   };
@@ -511,8 +511,8 @@ export const ProductTable: React.FC<ProductTableProps> = ({
       // Verifica se todos os termos de busca estão presentes em algum campo do produto
       const matchesAllTerms = searchTerms.every((term) => {
         return (
-          product.code?.toLowerCase().includes(term) ||
-          product.name?.toLowerCase().includes(term) ||
+          product.codigo?.toLowerCase().includes(term) ||
+          product.descricao?.toLowerCase().includes(term) ||
           product.ean?.toLowerCase().includes(term) ||
           product.reference?.toLowerCase().includes(term) ||
           product.descricao_complementar?.toLowerCase().includes(term)
@@ -573,7 +573,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
     if (products.length === 0) return 0;
 
     const totalOriginalPrice = products.reduce(
-      (acc, p) => acc + p.totalPrice,
+      (acc, p) => acc + p.valorTotal,
       0,
     );
     const totalDiscount = products.reduce((acc, p) => acc + p.discount, 0);
@@ -585,7 +585,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
 
   // Calcular a quantidade total de unidades
   const calculateTotalQuantity = (prods: Product[]) => {
-    return prods.reduce((acc, p) => acc + p.quantity, 0);
+    return prods.reduce((acc, p) => acc + p.quantidade, 0);
   };
 
   // Função para calcular o valor líquido total diretamente do XML
@@ -693,7 +693,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                 </div>
                 <div className="text-sm font-medium tabular-nums">
                   {sortedFilteredProducts
-                    .reduce((acc, p) => acc + p.totalPrice, 0)
+                    .reduce((acc, p) => acc + p.valorTotal, 0)
                     .toLocaleString('pt-BR', {
                       style: 'currency',
                       currency: 'BRL',
@@ -819,7 +819,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
               const tamanhoReferencia = extrairTamanhoDaReferencia(
                 product.reference,
               );
-              const tamanhoDescricao = extrairTamanhoDaDescricao(product.name);
+              const tamanhoDescricao = extrairTamanhoDaDescricao(product.descricao);
               const tamanho = tamanhoReferencia || tamanhoDescricao || '';
 
               return (
@@ -941,7 +941,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                         key={column.id}
                         className={cn(
                           'px-3 group relative text-sm hover:bg-slate-100 transition-colors text-center align-middle',
-                          column.id === 'name' &&
+                          column.id === 'descricao' &&
                             'break-words whitespace-normal',
                           column.id === 'xapuriPrice' &&
                             'bg-blue-50/50 hover:bg-blue-100/50',
@@ -983,18 +983,18 @@ export const ProductTable: React.FC<ProductTableProps> = ({
 // Função auxiliar para definir larguras mínimas baseadas no tipo de coluna
 const getMinWidth = (columnId: string): number => {
   switch (columnId) {
-    case 'code':
+    case 'codigo':
       return 120; // Código do produto
-    case 'name':
+    case 'descricao':
       return 250; // Descrição do produto
-    case 'quantity':
+    case 'quantidade':
       return 80; // Quantidade
-    case 'unitPrice':
+    case 'valorUnitario':
     case 'unitPriceWithDiscount': // Nova coluna de custo com desconto
     case 'netPrice':
     case 'xapuriPrice':
     case 'epitaPrice':
-    case 'totalPrice':
+    case 'valorTotal':
       return 110; // Campos de preço
     case 'reference':
       return 100; // Referência

--- a/frontend/src/components/product-preview/ProductTableRow.tsx
+++ b/frontend/src/components/product-preview/ProductTableRow.tsx
@@ -66,7 +66,7 @@ export const ProductTableRow: React.FC<ProductTableRowProps> = ({
       <TableCell>{product.unidade || '-'}</TableCell> {/* Changed to unidade */}
       <TableCell className="text-right">{formatNumber(product.quantidade)}</TableCell> {/* Changed to quantidade */}
       <TableCell className="text-right">{formatCurrency(product.valorUnitario)}</TableCell> {/* Changed to valorUnitario */}
-      <TableCell className="text-right">{formatCurrency(product.totalPrice)}</TableCell>
+      <TableCell className="text-right">{formatCurrency(product.valorTotal)}</TableCell>
       <TableCell className="text-right">{formatCurrency(unitSalePrice)}</TableCell>
       <TableCell className="text-right">{formatCurrency(product.discount)}</TableCell>
       <TableCell className="text-right">{formatCurrency(unitNetPrice)}</TableCell>

--- a/frontend/src/components/product-preview/ProductTags.tsx
+++ b/frontend/src/components/product-preview/ProductTags.tsx
@@ -44,8 +44,8 @@ export const ProductTags: React.FC<ProductTagsProps> = ({ product, index, onUpda
 
   // Gerar sugestões de tags com base na descrição do produto
   useEffect(() => {
-    if (product.name) {
-      const descricaoLowerCase = product.name.toLowerCase();
+    if (product.descricao) {
+      const descricaoLowerCase = product.descricao.toLowerCase();
       const sugestoes: string[] = [];
       
       CATEGORIAS_PREDEFINIDAS.forEach(categoria => {
@@ -73,7 +73,7 @@ export const ProductTags: React.FC<ProductTagsProps> = ({ product, index, onUpda
       
       setSuggestedTags(sugestoes);
     }
-  }, [product.name, product.color, product.size, product.brand, tags]);
+  }, [product.descricao, product.color, product.size, product.brand, tags]);
 
   const handleAddTag = () => {
     if (newTag.trim() && !tags.includes(newTag.trim())) {

--- a/frontend/src/components/product-preview/UnitValuesTable.tsx
+++ b/frontend/src/components/product-preview/UnitValuesTable.tsx
@@ -54,11 +54,11 @@ export const UnitValuesTable: React.FC<UnitValuesTableProps> = ({
       </TableHeader>
       <TableBody>
         {products.map((product, index) => {
-          const unitNetPrice = product.quantity > 0 ? product.netPrice / product.quantity : 0;
-          const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
-          const xapuriPrice = product.quantity > 0 ? 
+          const unitNetPrice = product.quantidade > 0 ? product.netPrice / product.quantidade : 0;
+          const unitDiscount = product.quantidade > 0 ? product.discount / product.quantidade : 0;
+          const xapuriPrice = product.quantidade > 0 ?
             roundPrice(calculateSalePrice({ ...product, netPrice: unitNetPrice }, xapuriMarkup), roundingType) : 0;
-          const epitaPrice = product.quantity > 0 ? 
+          const epitaPrice = product.quantidade > 0 ?
             roundPrice(calculateSalePrice({ ...product, netPrice: unitNetPrice }, epitaMarkup), roundingType) : 0;
           const isConfirmed = confirmedItems.has(index);
           const isHidden = hiddenItems.has(index);
@@ -68,16 +68,16 @@ export const UnitValuesTable: React.FC<UnitValuesTableProps> = ({
           }
 
           return (
-            <TableRow 
-              key={product.code} 
+            <TableRow
+              key={product.codigo}
               className={cn(
                 "hover:bg-slate-50 transition-colors",
                 isConfirmed && "bg-slate-100"
               )}
             >
               <TableCell>{product.ean || '-'}</TableCell>
-              <TableCell>{product.name}</TableCell>
-              <TableCell className="text-right">{formatCurrency(product.unitPrice)}</TableCell>
+              <TableCell>{product.descricao}</TableCell>
+              <TableCell className="text-right">{formatCurrency(product.valorUnitario)}</TableCell>
               <TableCell className="text-right">{formatCurrency(unitDiscount)}</TableCell>
               <TableCell className="text-right">{formatCurrency(unitNetPrice)}</TableCell>
               <TableCell className="text-right">{formatCurrency(xapuriPrice)}</TableCell>

--- a/frontend/src/components/product-preview/insights/PriceCharts.tsx
+++ b/frontend/src/components/product-preview/insights/PriceCharts.tsx
@@ -55,7 +55,7 @@ export const PriceCharts: React.FC<PriceChartsProps> = ({
   // Preparar dados para o gráfico de comparação de preços
   const preparePriceComparison = () => {
     return products.slice(0, 10).map(product => ({
-      name: product.name.substring(0, 15) + '...',
+      name: product.descricao.substring(0, 15) + '...',
       custo: product.netPrice,
       vendaXapuri: product.netPrice * (1 + xapuriMarkup / 100),
       vendaEpita: product.netPrice * (1 + epitaMarkup / 100),
@@ -65,7 +65,7 @@ export const PriceCharts: React.FC<PriceChartsProps> = ({
   // Preparar dados para o gráfico de margem por produto
   const prepareMarginByProduct = () => {
     return products.slice(0, 10).map(product => {
-      const custoUnitario = product.quantity > 0 ? product.netPrice / product.quantity : product.netPrice;
+      const custoUnitario = product.quantidade > 0 ? product.netPrice / product.quantidade : product.netPrice;
       const vendaXapuri = custoUnitario * (1 + xapuriMarkup / 100);
       const vendaEpita = custoUnitario * (1 + epitaMarkup / 100);
       
@@ -73,7 +73,7 @@ export const PriceCharts: React.FC<PriceChartsProps> = ({
       const margemEpita = ((vendaEpita - custoUnitario) / vendaEpita) * 100;
       
       return {
-        name: product.name.substring(0, 15) + '...',
+        name: product.descricao.substring(0, 15) + '...',
         margemXapuri: parseFloat(margemXapuri.toFixed(1)),
         margemEpita: parseFloat(margemEpita.toFixed(1)),
       };

--- a/frontend/src/components/product-preview/insights/PricingAnalysis.tsx
+++ b/frontend/src/components/product-preview/insights/PricingAnalysis.tsx
@@ -25,7 +25,7 @@ export const PricingAnalysis: React.FC<PricingAnalysisProps> = ({
 }) => {
   // Calculando os totais e médias
   const totalCost = products.reduce((sum, product) => sum + product.netPrice, 0);
-  const totalGrossCost = products.reduce((sum, product) => sum + product.totalPrice, 0);
+  const totalGrossCost = products.reduce((sum, product) => sum + product.valorTotal, 0);
   const freightCost = totalCost * (freightCostPercentage / 100);
   const taxCost = totalCost * (taxRate / 100);
   

--- a/frontend/src/components/product-preview/insights/ProductAnalysis.tsx
+++ b/frontend/src/components/product-preview/insights/ProductAnalysis.tsx
@@ -45,7 +45,7 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
         produtos: []
       };
     }
-    acc[tamanho].quantidade += product.quantity;
+    acc[tamanho].quantidade += product.quantidade;
     acc[tamanho].valorTotal += product.netPrice;
     acc[tamanho].produtos.push(product);
     return acc;
@@ -57,10 +57,10 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
       acc[product.ncm] = {
         quantidade: 0,
         valorTotal: 0,
-        descricao: NCM_DESCRIPTIONS[product.ncm] || product.name.split(' ')[0]
+        descricao: NCM_DESCRIPTIONS[product.ncm] || product.descricao.split(' ')[0]
       };
     }
-    acc[product.ncm].quantidade += product.quantity;
+    acc[product.ncm].quantidade += product.quantidade;
     acc[product.ncm].valorTotal += product.netPrice;
     return acc;
   }, {} as Record<string, { quantidade: number; valorTotal: number; descricao: string }>);
@@ -75,7 +75,7 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
   };
 
   const faixaPrecoStats = products.reduce((acc, product) => {
-    const precoUnitario = product.netPrice / product.quantity;
+    const precoUnitario = product.netPrice / product.quantidade;
     const faixa = getFaixaPreco(precoUnitario);
     if (!acc[faixa]) {
       acc[faixa] = {
@@ -84,7 +84,7 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
         produtos: []
       };
     }
-    acc[faixa].quantidade += product.quantity;
+    acc[faixa].quantidade += product.quantidade;
     acc[faixa].valorTotal += product.netPrice;
     acc[faixa].produtos.push(product);
     return acc;

--- a/frontend/src/components/product-preview/productCalculations.ts
+++ b/frontend/src/components/product-preview/productCalculations.ts
@@ -2,8 +2,8 @@ import { Product } from '../../types/nfe';
 
 // Calcula o custo com desconto (Custo Bruto - Desconto Médio)
 export const calculateCustoComDesconto = (product: Product): number => {
-  const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
-  return product.unitPrice - unitDiscount;
+  const unitDiscount = product.quantidade > 0 ? product.discount / product.quantidade : 0;
+  return product.valorUnitario - unitDiscount;
 };
 
 // Calcula o custo líquido (Custo c/ desconto × (1 + Imposto de Entrada / 100))
@@ -37,7 +37,7 @@ export const calculateTotals = (products: Product[], impostoEntrada: number) => 
     const custoComDesconto = calculateCustoComDesconto(product);
     const custoLiquido = calculateCustoLiquido(product, impostoEntrada);
     return {
-      totalBruto: acc.totalBruto + product.totalPrice,
+      totalBruto: acc.totalBruto + product.valorTotal,
       totalDesconto: acc.totalDesconto + product.discount,
       totalLiquido: acc.totalLiquido + product.netPrice,
       totalCustoLiquido: acc.totalCustoLiquido + custoLiquido,

--- a/frontend/src/components/product-preview/productDescription.ts
+++ b/frontend/src/components/product-preview/productDescription.ts
@@ -4,7 +4,7 @@ import { Product } from '../../types/nfe';
 const formatProductName = (name: string): string => {
   // Remove códigos específicos no final do nome (como SCY765/02)
   const nameWithoutCode = name.replace(/\s+\w+\/\d+$/, '');
-  
+
   // Capitaliza cada palavra
   return nameWithoutCode
     .split(' ')
@@ -21,9 +21,9 @@ const formatProductName = (name: string): string => {
 
 export const generateProductDescription = (product: Product): string => {
   const parts: string[] = [];
-  
+
   // Nome do produto formatado
-  const formattedName = formatProductName(product.name);
+  const formattedName = formatProductName(product.descricao);
   parts.push(formattedName);
 
   // Dados técnicos em uma seção separada
@@ -35,8 +35,8 @@ export const generateProductDescription = (product: Product): string => {
   }
 
   // Adiciona código do produto se disponível e diferente da referência
-  if (product.code && product.code !== product.reference) {
-    technicalInfo.push(product.code);
+  if (product.codigo && product.codigo !== product.reference) {
+    technicalInfo.push(product.codigo);
   }
 
   // Adiciona EAN se disponível (sem o prefixo EAN)

--- a/frontend/src/components/product-preview/types/column.ts
+++ b/frontend/src/components/product-preview/types/column.ts
@@ -22,17 +22,17 @@ export const getDefaultColumns = (): Column[] => [
     minWidth: 48,
     order: 0
   },
-  { 
-    id: 'code', 
-    header: 'Código', 
+  {
+    id: 'codigo',
+    header: 'Código',
     initiallyVisible: true,
     width: 'w-fit',
     minWidth: 100,
     order: 1
   },
-  { 
-    id: 'name', 
-    header: 'Descrição', 
+  {
+    id: 'descricao',
+    header: 'Descrição',
     initiallyVisible: true,
     width: 'w-fit',
     minWidth: 300,
@@ -86,18 +86,18 @@ export const getDefaultColumns = (): Column[] => [
     minWidth: 80,
     order: 8
   },
-  { 
-    id: 'uom', 
-    header: 'UN', 
+  {
+    id: 'unidade',
+    header: 'UN',
     initiallyVisible: true,
     width: 'w-fit',
     minWidth: 56,
     order: 9
   },
-  { 
-    id: 'quantity', 
-    header: 'Qtd.', 
-    initiallyVisible: true, 
+  {
+    id: 'quantidade',
+    header: 'Qtd.',
+    initiallyVisible: true,
     alignment: 'right',
     width: 'w-fit',
     minWidth: 80,
@@ -105,9 +105,9 @@ export const getDefaultColumns = (): Column[] => [
     format: (value: number) => formatNumber(value)
   },
   {
-    id: 'unitPrice',
-    header: 'Custo Bruto', 
-    initiallyVisible: true, 
+    id: 'valorUnitario',
+    header: 'Custo Bruto',
+    initiallyVisible: true,
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
@@ -116,22 +116,22 @@ export const getDefaultColumns = (): Column[] => [
   },
   {
     id: 'unitPriceWithDiscount',
-    header: 'Custo c/ desconto', 
-    initiallyVisible: true, 
+    header: 'Custo c/ desconto',
+    initiallyVisible: true,
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
     order: 12,
     format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => {
-      const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
-      return product.unitPrice - unitDiscount;
+      const unitDiscount = product.quantidade > 0 ? product.discount / product.quantidade : 0;
+      return product.valorUnitario - unitDiscount;
     }
   },
   {
-    id: 'totalPrice',
-    header: 'Total', 
-    initiallyVisible: true, 
+    id: 'valorTotal',
+    header: 'Total',
+    initiallyVisible: true,
     alignment: 'right',
     width: 'w-fit',
     minWidth: 112,
@@ -148,8 +148,8 @@ export const getDefaultColumns = (): Column[] => [
     order: 14,
     format: (value: number) => formatCurrency(value),
     getValue: (product: Product) => {
-      const unitDiscount = product.quantity > 0 ? product.discount / product.quantity : 0;
-      const custoComDesconto = product.unitPrice - unitDiscount;
+      const unitDiscount = product.quantidade > 0 ? product.discount / product.quantidade : 0;
+      const custoComDesconto = product.valorUnitario - unitDiscount;
       // Aqui assumimos que o impostoEntrada está disponível globalmente ou é passado como parâmetro
       // O valor real será calculado no ProductTable.tsx
       return custoComDesconto; // O valor real com imposto será calculado no ProductTable
@@ -186,7 +186,7 @@ export const getDefaultColumns = (): Column[] => [
     minWidth: 112,
     order: 15,
     format: (value: number) => formatCurrency(value),
-    getValue: (product: Product) => product.quantity > 0 ? product.discount / product.quantity : 0
+    getValue: (product: Product) => product.quantidade > 0 ? product.discount / product.quantidade : 0
   },
   {
     id: 'xapuriPrice',
@@ -220,9 +220,9 @@ export const getDefaultColumns = (): Column[] => [
 ];
 
 export const compactColumns = [
-  'name',
+  'descricao',
   'ean',
-  'quantity',
+  'quantidade',
   'netPrice',
   'xapuriPrice',
   'epitaPrice'

--- a/frontend/src/hooks/useNFEStorage.ts
+++ b/frontend/src/hooks/useNFEStorage.ts
@@ -9,8 +9,6 @@ export interface NFE {
   valor: number;
   itens: number;
   produtos: any[];
-  brandName?: string;
-  invoiceNumber?: string;
   isFavorite?: boolean;
   chaveNFE?: string;
   impostoEntrada: number;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,8 +35,8 @@ const Dashboard = () => {
   // Cálculos dos totais com verificações de segurança
   const totalNotas = savedNFEs.length;
   const totalProdutos = savedNFEs.reduce((acc, nfe) => acc + (Array.isArray(nfe.produtos) ? nfe.produtos.length : 0), 0);
-  const quantidadeTotal = savedNFEs.reduce((acc, nfe) => 
-    acc + (Array.isArray(nfe.produtos) ? nfe.produtos.reduce((sum, prod) => sum + (Number(prod.quantity) || 0), 0) : 0), 0);
+  const quantidadeTotal = savedNFEs.reduce((acc, nfe) =>
+    acc + (Array.isArray(nfe.produtos) ? nfe.produtos.reduce((sum, prod) => sum + (Number(prod.quantidade) || 0), 0) : 0), 0);
   const valorTotal = savedNFEs.reduce((acc, nfe) => acc + (Number(nfe.valor) || 0), 0);
   const totalImpostos = valorTotal * 0.17; // 17% de impostos
   const notasFavoritas = savedNFEs.filter(nfe => nfe.isFavorite).length;

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -86,7 +86,7 @@ const Index = () => {
   // Função para gerar ID estável do produto (mesma regra do ProductPreview)
   const getProductId = (p: Product, index: number) => {
     if (p.ean && p.ean.length > 0) return String(p.ean);
-    if (p.code && p.code.length > 0) return `cod:${p.code}:${index}`;
+    if (p.codigo && p.codigo.length > 0) return `cod:${p.codigo}:${index}`;
     if (p.reference) return `ref:${p.reference}:${index}`;
     return `idx:${index}`;
   };
@@ -177,38 +177,32 @@ const Index = () => {
             aliquotaIPI: p.aliquotaIPI ?? 0,
             xapuriPrice: 0,
             epitaPrice: 0,
-            code: p.codigo ?? '',
-            name: p.descricao ?? '',
             ean: p.ean ?? '',
             reference: p.reference ?? '',
             brand: p.brand ?? '',
-            totalPrice: p.valorTotal ?? 0,
             discount: p.discount ?? 0,
             netPrice: (() => {
               const valorTotal = p.valorTotal ?? 0;
               const discount = p.discount ?? 0;
-              const unitPrice = p.valorUnitario ?? 0;
+              const valorUnitario = p.valorUnitario ?? 0;
               const quantidade = p.quantidade ?? 1;
               
               // Se valorTotal for muito alto (mais de 10x o preço unitário), usar cálculo alternativo
-              if (valorTotal > unitPrice * quantidade * 10) {
-                console.warn('Valor total muito alto detectado:', { valorTotal, unitPrice, quantidade, discount });
+              if (valorTotal > valorUnitario * quantidade * 10) {
+                console.warn('Valor total muito alto detectado:', { valorTotal, valorUnitario, quantidade, discount });
                 // Calcular baseado no preço unitário
-                return (unitPrice * quantidade) - discount;
+                return (valorUnitario * quantidade) - discount;
               }
-              
+
               return valorTotal - discount;
             })(),
-            quantity: p.quantidade ?? 0,
             imageUrl: p.imageUrl ?? '',
             tags: [],
             salePrice: 0,
-            uom: p.unidade ?? '',
             color: 'Cor não cadastrada',
             size: undefined,
             fornecedor: undefined,
             descricao_complementar: p.descricao_complementar ?? '',
-            unitPrice: p.valorUnitario ?? 0,
             freteProporcional: p.freteProporcional ?? 0,
             custoExtra: p.custoExtra ?? 0,
           };
@@ -380,38 +374,32 @@ const Index = () => {
         aliquotaIPI: p.aliquotaIPI ?? 0,
         xapuriPrice: 0,
         epitaPrice: 0,
-        code: p.codigo ?? '',
-        name: p.descricao ?? '',
         ean: p.ean ?? '',
         reference: p.reference ?? '',
         brand: p.brand ?? '',
-        totalPrice: p.valorTotal ?? 0,
         discount: p.discount ?? 0,
         netPrice: (() => {
           const valorTotal = p.valorTotal ?? 0;
           const discount = p.discount ?? 0;
-          const unitPrice = p.valorUnitario ?? 0;
+          const valorUnitario = p.valorUnitario ?? 0;
           const quantidade = p.quantidade ?? 1;
           
           // Se valorTotal for muito alto (mais de 10x o preço unitário), usar cálculo alternativo
-          if (valorTotal > unitPrice * quantidade * 10) {
-            console.warn('Valor total muito alto detectado:', { valorTotal, unitPrice, quantidade, discount });
+          if (valorTotal > valorUnitario * quantidade * 10) {
+            console.warn('Valor total muito alto detectado:', { valorTotal, valorUnitario, quantidade, discount });
             // Calcular baseado no preço unitário
-            return (unitPrice * quantidade) - discount;
+            return (valorUnitario * quantidade) - discount;
           }
-          
+
           return valorTotal - discount;
         })(),
-        quantity: p.quantidade ?? 0,
         imageUrl: p.imageUrl ?? '',
         tags: [],
         salePrice: 0,
-        uom: p.unidade ?? '',
         color: 'Cor não cadastrada',
         size: undefined,
         fornecedor: undefined,
         descricao_complementar: p.descricao_complementar ?? '',
-        unitPrice: p.valorUnitario ?? 0,
         freteProporcional: p.freteProporcional ?? 0,
         custoExtra: p.custoExtra ?? 0,
       }),

--- a/frontend/src/pages/Produtos.tsx
+++ b/frontend/src/pages/Produtos.tsx
@@ -63,11 +63,11 @@ const Produtos = () => {
         product.codigo?.toString().toLowerCase().includes(searchLower) ||
         product.descricao?.toLowerCase().includes(searchLower) ||
         product.ean?.toString().includes(searchLower) ||
-        product.referencia?.toLowerCase().includes(searchLower) ||
+        product.reference?.toLowerCase().includes(searchLower) ||
         product.fornecedor?.toLowerCase().includes(searchLower) ||
         product.descricao_complementar?.toLowerCase().includes(searchLower);
 
-      const matchesImageFilter = !settings.showOnlyWithImage || product.imagem;
+      const matchesImageFilter = !settings.showOnlyWithImage || product.imageUrl;
       const matchesHiddenFilter =
         !settings.showOnlyHidden || settings.hiddenItems.has(product.id);
 
@@ -108,16 +108,16 @@ const Produtos = () => {
 
   // Estatísticas dos produtos
   const totalQuantidade = filteredProducts.reduce(
-    (acc, prod) => acc + (prod.quantity || 0),
+    (acc, prod) => acc + (prod.quantidade || 0),
     0,
   );
   const totalUnidades = filteredProducts.length;
   const valorTotal = filteredProducts.reduce(
-    (acc, prod) => acc + (prod.valor || 0),
+    (acc, prod) => acc + (prod.valorTotal || 0),
     0,
   );
   const descontoMedio =
-    filteredProducts.reduce((acc, prod) => acc + (prod.desconto || 0), 0) /
+    filteredProducts.reduce((acc, prod) => acc + (prod.discount || 0), 0) /
       filteredProducts.length || 0;
 
   // Renderizar números de página

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { Product } from '@/types/nfe';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4005/api';
 const DEBUG = import.meta.env.VITE_DEBUG === 'true';
@@ -60,32 +61,6 @@ export interface NFE {
   isFavorite?: boolean;
   createdAt?: string;
   updatedAt?: string;
-}
-
-export interface Product {
-  id?: number;
-  nfeId?: string;
-  codigo: string;
-  descricao: string;
-  ncm?: string;
-  cfop?: string;
-  unidade?: string;
-  quantidade: number;
-  valorUnitario: number;
-  valorTotal: number;
-  baseCalculoICMS?: number;
-  valorICMS?: number;
-  aliquotaICMS?: number;
-  baseCalculoIPI?: number;
-  valorIPI?: number;
-  aliquotaIPI?: number;
-  ean?: string;
-  reference?: string;
-  brand?: string;
-  imageUrl?: string;
-  descricao_complementar?: string;
-  custoExtra?: number;
-  freteProporcional?: number;
 }
 
 // API de NFEs

--- a/frontend/src/types/nfe.ts
+++ b/frontend/src/types/nfe.ts
@@ -15,24 +15,18 @@ export interface Product {
   aliquotaIPI: number;
   xapuriPrice?: number;
   epitaPrice?: number;
-  code: string;
-  name: string;
   ean?: string;
   reference?: string;
   brand?: string;
-  totalPrice: number; // total extraído do XML
-  netPrice: number; // total líquido (totalPrice - discount)
+  netPrice: number; // total líquido (valorTotal - discount)
   discount: number;
-  quantity: number;
   imageUrl?: string;
   tags?: string[];
   salePrice: number; // preço de venda calculado
-  uom?: string;
   color?: string;
   size?: string;
   fornecedor?: string;
   descricao_complementar?: string;
-  unitPrice: number;
   freteProporcional?: number;
   custoExtra?: number;
 }
@@ -52,8 +46,6 @@ export interface NFE {
   isFavorite?: boolean;
   itens?: number;
   valor?: number;
-  brandName?: string;
-  invoiceNumber?: string;
   impostoEntrada: number;
 }
 
@@ -78,9 +70,7 @@ export interface SavedNFe {
   id: string;
   products: Product[];
   date: string;
-  name: string;
-  invoiceNumber?: string;
-  brandName?: string;
+  fornecedor: string;
   hiddenItems?: Set<number>;
   xapuriMarkup?: number;
   epitaMarkup?: number;

--- a/frontend/src/utils/nfeParser.ts
+++ b/frontend/src/utils/nfeParser.ts
@@ -98,11 +98,11 @@ export const parseNFeXML = (xmlText: string): Product[] => {
 
     const icmsInfo = getICMSInfo(icms);
 
-    const quantity = parseNumber(getElementText(prod, 'qCom'));
-    const unitPrice = parseNumber(getElementText(prod, 'vUnCom'));
-    const totalPrice = parseNumber(getElementText(prod, 'vProd'));
+    const quantidade = parseNumber(getElementText(prod, 'qCom'));
+    const valorUnitario = parseNumber(getElementText(prod, 'vUnCom'));
+    const valorTotal = parseNumber(getElementText(prod, 'vProd'));
     const discount = parseNumber(getElementText(prod, 'vDesc'));
-    const netPrice = totalPrice - discount;
+    const netPrice = valorTotal - discount;
 
     const nome = getElementText(prod, 'xProd');
     const codigo = getElementText(prod, 'cProd');
@@ -115,31 +115,25 @@ export const parseNFeXML = (xmlText: string): Product[] => {
     const { brand, confidence } = identifyBrand(referencia, nome);
 
     const product: Product = {
-      code: codigo,
+      codigo,
       ean: getElementText(prod, 'cEAN'),
-      name: nome,
+      descricao: nome,
       ncm: getElementText(prod, 'NCM'),
       cfop: getElementText(prod, 'CFOP'),
-      uom: getElementText(prod, 'uCom'),
-      quantity: quantity,
-      unitPrice: unitPrice,
-      totalPrice: totalPrice,
-      discount: discount,
-      netPrice: netPrice,
+      unidade: getElementText(prod, 'uCom'),
+      quantidade,
+      valorUnitario,
+      valorTotal,
+      discount,
+      netPrice,
       color: corIdentificada || '',
       size: tamanho,
       reference: referencia,
       salePrice: netPrice * 1.3,
-      brand: brand,
+      brand,
       descricao_complementar: formatarDescricaoComplementar(
         item.getElementsByTagName('infAdProd')[0]?.textContent || '',
       ),
-      codigo: codigo,
-      descricao: nome,
-      unidade: getElementText(prod, 'uCom'),
-      quantidade: quantity,
-      valorUnitario: unitPrice,
-      valorTotal: totalPrice,
       baseCalculoICMS: 0,
       valorICMS: 0,
       aliquotaICMS: 0,


### PR DESCRIPTION
## Summary
- remove English aliases from Product interface
- update components and services to use Portuguese field names
- unify API typings with shared Product definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add73dceb083258e9da1043dcbafc4