### PR TITLE
build: add backend build step to e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Install backend dependencies
         working-directory: server
         run: npm ci
+      - name: Build backend
+        working-directory: server
+        run: npm run build
       - name: Run e2e tests
         env:
           PORT: 3001


### PR DESCRIPTION
## Summary
- build backend before executing e2e tests in CI

## Testing
- `npm test` (fails: The requested module '../models/nfeModel.js' does not provide an export named 'getNfeByChave')

------
https://chatgpt.com/codex/tasks/task_e_68ae6dc77e68832583f79d2d55bc4aa4