### PR TITLE
refactor: use format helpers

### DIFF
--- a/frontend/src/components/product-preview/ProductTable.tsx
+++ b/frontend/src/components/product-preview/ProductTable.tsx
@@ -31,8 +31,8 @@ import { toast } from 'sonner';
 import {
   formatNumberForCopy,
   formatCurrency,
-  formatNumber,
-} from '../../utils/formatters';
+  formatPercent,
+} from '@/utils/formatters';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
@@ -692,12 +692,12 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                   Valor Total
                 </div>
                 <div className="text-sm font-medium tabular-nums">
-                  {sortedFilteredProducts
-                    .reduce((acc, p) => acc + p.totalPrice, 0)
-                    .toLocaleString('pt-BR', {
-                      style: 'currency',
-                      currency: 'BRL',
-                    })}
+                  {formatCurrency(
+                    sortedFilteredProducts.reduce(
+                      (acc, p) => acc + p.totalPrice,
+                      0,
+                    ),
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -707,12 +707,9 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                   Valor Líquido
                 </div>
                 <div className="text-sm font-medium tabular-nums">
-                  {calculateTotalNetValue(
-                    sortedFilteredProducts,
-                  ).toLocaleString('pt-BR', {
-                    style: 'currency',
-                    currency: 'BRL',
-                  })}
+                  {formatCurrency(
+                    calculateTotalNetValue(sortedFilteredProducts),
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -722,7 +719,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                   Desconto Médio
                 </div>
                 <div className="text-sm font-medium tabular-nums">
-                  {averageDiscountPercent.toFixed(1)}%
+                  {formatPercent(averageDiscountPercent)}
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/components/product-preview/insights/PriceCharts.tsx
+++ b/frontend/src/components/product-preview/insights/PriceCharts.tsx
@@ -16,7 +16,7 @@ import {
   LineChart,
   Line
 } from 'recharts';
-import { formatCurrency } from '../../../utils/formatters';
+import { formatCurrency, formatPercent } from '@/utils/formatters';
 
 interface PriceChartsProps {
   products: Product[];
@@ -83,10 +83,6 @@ export const PriceCharts: React.FC<PriceChartsProps> = ({
   // Formatar valores para o tooltip
   const formatTooltipValue = (value: number) => {
     return formatCurrency(value);
-  };
-
-  const formatPercentage = (value: number) => {
-    return `${value.toFixed(1)}%`;
   };
 
   const priceDistribution = preparePriceDistribution();
@@ -166,7 +162,7 @@ export const PriceCharts: React.FC<PriceChartsProps> = ({
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
                 <YAxis />
-                <Tooltip formatter={formatPercentage} />
+                <Tooltip formatter={(value: number) => formatPercent(value)} />
                 <Legend />
                 <Line 
                   type="monotone" 

--- a/frontend/src/pages/Produtos.tsx
+++ b/frontend/src/pages/Produtos.tsx
@@ -17,6 +17,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';
 import { useProductSettings } from '@/hooks/useProductSettings';
 import type { Product } from '@/types/nfe';
+import { formatPercent } from '@/utils/formatters';
 
 const ITEMS_PER_PAGE = 50;
 
@@ -225,7 +226,7 @@ const Produtos = () => {
         <Card>
           <CardContent className="pt-6">
             <div className="text-2xl font-bold">
-              {descontoMedio.toFixed(1)}%
+              {formatPercent(descontoMedio)}
             </div>
             <div className="text-sm text-muted-foreground">Desconto Médio</div>
           </CardContent>

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -9,6 +9,14 @@ export const formatNumber = (value: number): string => {
   return new Intl.NumberFormat('pt-BR').format(value);
 };
 
+export const formatPercent = (value: number): string => {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value / 100);
+};
+
 // Função para converter número para formato brasileiro ao copiar
 export const formatNumberForCopy = (
   value: number,

--- a/server/__tests__/nfeRoutes.test.js
+++ b/server/__tests__/nfeRoutes.test.js
@@ -7,6 +7,7 @@ import config from '../config/index.js';
 await jest.unstable_mockModule('../models/nfeModel.js', () => ({
   getAllNfes: jest.fn(),
   getNfeById: jest.fn(),
+  getNfeByChave: jest.fn(),
   saveNfe: jest.fn(),
   updateNfe: jest.fn(),
   deleteNfe: jest.fn(),


### PR DESCRIPTION
## Summary
- use shared formatter imports in product table
- add formatPercent helper and apply in product views

## Testing
- `npm test` (failed: sh: 1: vitest: not found)
- `npm run lint` (failed: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68af297b0aa48325a8899e411dea4f15