### PR TITLE
refactor: rename size extractors and translate comments

### DIFF
--- a/src/components/product-preview/ProductTable.tsx
+++ b/src/components/product-preview/ProductTable.tsx
@@ -11,7 +11,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { extractSizeFromDescription, extrairTamanhoDaReferencia } from '../../utils/sizeParser';
+import { extractSizeFromDescription, extractSizeFromReference } from '../../utils/sizeParser';
 import { ResizableBox } from 'react-resizable';
 import 'react-resizable/css/styles.css';
 import { ProductFilter, ProductFilters } from './ProductFilter';
@@ -648,18 +648,18 @@ export const ProductTable: React.FC<ProductTableProps> = ({
               // Calcular o custo com desconto (Custo Bruto - Desconto Médio)
               const custoComDesconto = calculateCustoComDesconto(product);
               
-              // Calcular o custo líquido (Custo c/ desconto + Imposto de Entrada)
+              // Calculate net cost (Cost with discount + Entry Tax)
               const custoLiquido = calculateCustoLiquido(product, impostoEntrada);
-              // Novo: custo líquido + frete proporcional
+              // New: net cost + proportional freight
               const custoLiquidoComFrete = custoLiquido + (product.freightShare || 0);
-              
-              // Calcular preços de venda com base no custo líquido + frete proporcional
+
+              // Calculate sale prices based on net cost + proportional freight
               const xapuriPrice = roundPrice(calculateSalePrice({ ...product, netPrice: custoLiquidoComFrete }, xapuriMarkup), roundingType);
               const epitaPrice = roundPrice(calculateSalePrice({ ...product, netPrice: custoLiquidoComFrete }, epitaMarkup), roundingType);
-              
-              const tamanhoReferencia = extrairTamanhoDaReferencia(product.reference);
-              const tamanhoDescricao = extractSizeFromDescription(product.description);
-              const tamanho = tamanhoReferencia || tamanhoDescricao || '';
+
+              const referenceSize = extractSizeFromReference(product.reference);
+              const descriptionSize = extractSizeFromDescription(product.description);
+              const size = referenceSize || descriptionSize || '';
 
               return (
                 <TableRow 
@@ -726,7 +726,7 @@ export const ProductTable: React.FC<ProductTableProps> = ({
                       const netCostWithFreight = netCost + (product.freightShare || 0);
                       value = roundPrice(calculateSalePrice({ ...product, netPrice: netCostWithFreight }, epitaMarkup), roundingType) + extraCost;
                     }
-                    if (column.id === 'size') value = tamanho;
+                    if (column.id === 'size') value = size;
                     if (column.id === 'netPrice') {
                       // Net cost = unit cost + proportional freight
                       const netCost = calculateCustoLiquido(product, impostoEntrada);

--- a/src/components/product-preview/insights/ProductAnalysis.tsx
+++ b/src/components/product-preview/insights/ProductAnalysis.tsx
@@ -9,20 +9,20 @@ interface ProductAnalysisProps {
   products: Product[];
 }
 
-// Mapeamento de NCM para descrições detalhadas
+// Mapping of NCM to detailed descriptions
 const NCM_DESCRIPTIONS: Record<string, string> = {
   '39249000': 'Bicos de Mamadeira e acessórios plásticos para alimentação infantil',
   '39241000': 'Conjuntos de mamadeiras e acessórios plásticos',
   '96032100': 'Escovas de dentes, incluídas as escovas para dentaduras',
   '40149090': 'Artigos de higiene ou de farmácia de borracha vulcanizada',
-  // Adicione mais NCMs conforme necessário
+  // Add more NCMs as needed
 };
 
 export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) => {
-  // Análises por tamanho com normalização
-  const normalizeTamanho = (tamanho: string): string => {
-    const normalizado = tamanho.toUpperCase().trim();
-    const mapeamento: Record<string, string> = {
+  // Size analysis with normalization
+  const normalizeSize = (size: string): string => {
+    const normalized = size.toUpperCase().trim();
+    const mapping: Record<string, string> = {
       'P': 'PEQUENO',
       'M': 'MÉDIO',
       'G': 'GRANDE',
@@ -33,65 +33,65 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
       '12-18M': '12-18 MESES',
       '18-24M': '18-24 MESES',
     };
-    return mapeamento[normalizado] || tamanho;
+    return mapping[normalized] || size;
   };
 
-  const tamanhoStats = products.reduce((acc, product) => {
-    const tamanho = normalizeTamanho(product.size || 'Não especificado');
-    if (!acc[tamanho]) {
-      acc[tamanho] = {
-        quantidade: 0,
-        valorTotal: 0,
-        produtos: []
+  const sizeStats = products.reduce((acc, product) => {
+    const size = normalizeSize(product.size || 'Not specified');
+    if (!acc[size]) {
+      acc[size] = {
+        quantity: 0,
+        totalValue: 0,
+        products: []
       };
     }
-    acc[tamanho].quantidade += product.quantity;
-    acc[tamanho].valorTotal += product.netPrice;
-    acc[tamanho].produtos.push(product);
+    acc[size].quantity += product.quantity;
+    acc[size].totalValue += product.netPrice;
+    acc[size].products.push(product);
     return acc;
-  }, {} as Record<string, { quantidade: number; valorTotal: number; produtos: Product[] }>);
+  }, {} as Record<string, { quantity: number; totalValue: number; products: Product[] }>);
 
-  // Análises por NCM com descrições detalhadas
+  // NCM analysis with detailed descriptions
   const ncmStats = products.reduce((acc, product) => {
     if (!acc[product.ncm]) {
       acc[product.ncm] = {
-        quantidade: 0,
-        valorTotal: 0,
-        descricao: NCM_DESCRIPTIONS[product.ncm] || product.description.split(' ')[0]
+        quantity: 0,
+        totalValue: 0,
+        description: NCM_DESCRIPTIONS[product.ncm] || product.description.split(' ')[0]
       };
     }
-    acc[product.ncm].quantidade += product.quantity;
-    acc[product.ncm].valorTotal += product.netPrice;
+    acc[product.ncm].quantity += product.quantity;
+    acc[product.ncm].totalValue += product.netPrice;
     return acc;
-  }, {} as Record<string, { quantidade: number; valorTotal: number; descricao: string }>);
+  }, {} as Record<string, { quantity: number; totalValue: number; description: string }>);
 
-  // Análise por faixa de preço expandida
-  const getFaixaPreco = (preco: number): string => {
-    if (preco <= 50) return 'Até R$ 50';
-    if (preco <= 100) return 'R$ 51 a R$ 100';
-    if (preco <= 200) return 'R$ 101 a R$ 200';
-    if (preco <= 500) return 'R$ 201 a R$ 500';
+  // Expanded price range analysis
+  const getPriceRange = (price: number): string => {
+    if (price <= 50) return 'Até R$ 50';
+    if (price <= 100) return 'R$ 51 a R$ 100';
+    if (price <= 200) return 'R$ 101 a R$ 200';
+    if (price <= 500) return 'R$ 201 a R$ 500';
     return 'Acima de R$ 500';
   };
 
-  const faixaPrecoStats = products.reduce((acc, product) => {
-    const precoUnitario = product.netPrice / product.quantity;
-    const faixa = getFaixaPreco(precoUnitario);
-    if (!acc[faixa]) {
-      acc[faixa] = {
-        quantidade: 0,
-        valorTotal: 0,
-        produtos: []
+  const priceRangeStats = products.reduce((acc, product) => {
+    const unitPrice = product.netPrice / product.quantity;
+    const range = getPriceRange(unitPrice);
+    if (!acc[range]) {
+      acc[range] = {
+        quantity: 0,
+        totalValue: 0,
+        products: []
       };
     }
-    acc[faixa].quantidade += product.quantity;
-    acc[faixa].valorTotal += product.netPrice;
-    acc[faixa].produtos.push(product);
+    acc[range].quantity += product.quantity;
+    acc[range].totalValue += product.netPrice;
+    acc[range].products.push(product);
     return acc;
-  }, {} as Record<string, { quantidade: number; valorTotal: number; produtos: Product[] }>);
+  }, {} as Record<string, { quantity: number; totalValue: number; products: Product[] }>);
 
-  // Calcula o valor total para percentuais
-  const valorTotalProdutos = products.reduce((acc, prod) => acc + prod.netPrice, 0);
+  // Calculate total value for percentages
+  const totalProductValue = products.reduce((acc, prod) => acc + prod.netPrice, 0);
 
   return (
     <div className="space-y-8">
@@ -111,24 +111,24 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {Object.entries(tamanhoStats)
-                .sort((a, b) => b[1].valorTotal - a[1].valorTotal)
-                .map(([tamanho, stats]) => {
-                  const percentualTotal = (stats.valorTotal / valorTotalProdutos) * 100;
+              {Object.entries(sizeStats)
+                .sort((a, b) => b[1].totalValue - a[1].totalValue)
+                .map(([size, stats]) => {
+                  const totalPercentage = (stats.totalValue / totalProductValue) * 100;
                   return (
-                    <TableRow key={tamanho}>
-                      <TableCell className="font-medium">{tamanho}</TableCell>
+                    <TableRow key={size}>
+                      <TableCell className="font-medium">{size}</TableCell>
                       <TableCell className="text-right">
-                        {formatNumber(stats.quantidade)}
+                        {formatNumber(stats.quantity)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {formatCurrency(stats.valorTotal)}
+                        {formatCurrency(stats.totalValue)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {formatCurrency(stats.valorTotal / stats.quantidade)}
+                        {formatCurrency(stats.totalValue / stats.quantity)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {percentualTotal.toFixed(1)}%
+                        {totalPercentage.toFixed(1)}%
                       </TableCell>
                     </TableRow>
                   );
@@ -155,21 +155,21 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
             </TableHeader>
             <TableBody>
               {Object.entries(ncmStats)
-                .sort((a, b) => b[1].valorTotal - a[1].valorTotal)
+                .sort((a, b) => b[1].totalValue - a[1].totalValue)
                 .map(([ncm, stats]) => {
-                  const percentualTotal = (stats.valorTotal / valorTotalProdutos) * 100;
+                  const totalPercentage = (stats.totalValue / totalProductValue) * 100;
                   return (
                     <TableRow key={ncm}>
                       <TableCell className="font-medium">{ncm}</TableCell>
-                      <TableCell>{stats.descricao}</TableCell>
+                      <TableCell>{stats.description}</TableCell>
                       <TableCell className="text-right">
-                        {formatNumber(stats.quantidade)}
+                        {formatNumber(stats.quantity)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {formatCurrency(stats.valorTotal)}
+                        {formatCurrency(stats.totalValue)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {percentualTotal.toFixed(1)}%
+                        {totalPercentage.toFixed(1)}%
                       </TableCell>
                     </TableRow>
                   );
@@ -195,34 +195,34 @@ export const ProductAnalysis: React.FC<ProductAnalysisProps> = ({ products }) =>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {Object.entries(faixaPrecoStats)
+              {Object.entries(priceRangeStats)
                 .sort((a, b) => {
-                  const ordem = [
+                  const order = [
                     'Até R$ 50',
                     'R$ 51 a R$ 100',
                     'R$ 101 a R$ 200',
                     'R$ 201 a R$ 500',
                     'Acima de R$ 500'
                   ];
-                  return ordem.indexOf(a[0]) - ordem.indexOf(b[0]);
+                  return order.indexOf(a[0]) - order.indexOf(b[0]);
                 })
-                .map(([faixa, stats]) => {
-                  const percentualTotal = (stats.valorTotal / valorTotalProdutos) * 100;
-                  const precoMedio = stats.valorTotal / stats.quantidade;
+                .map(([range, stats]) => {
+                  const totalPercentage = (stats.totalValue / totalProductValue) * 100;
+                  const averagePrice = stats.totalValue / stats.quantity;
                   return (
-                    <TableRow key={faixa}>
-                      <TableCell className="font-medium">{faixa}</TableCell>
+                    <TableRow key={range}>
+                      <TableCell className="font-medium">{range}</TableCell>
                       <TableCell className="text-right">
-                        {formatNumber(stats.quantidade)}
+                        {formatNumber(stats.quantity)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {formatCurrency(stats.valorTotal)}
+                        {formatCurrency(stats.totalValue)}
                       </TableCell>
                       <TableCell className="text-right">
-                        {percentualTotal.toFixed(1)}%
+                        {totalPercentage.toFixed(1)}%
                       </TableCell>
                       <TableCell className="text-right">
-                        {formatCurrency(precoMedio)}
+                        {formatCurrency(averagePrice)}
                       </TableCell>
                     </TableRow>
                   );

--- a/src/components/product-preview/productDescription.ts
+++ b/src/components/product-preview/productDescription.ts
@@ -2,14 +2,14 @@
 import { Product } from '../../types/nfe';
 
 const formatProductDescription = (description: string): string => {
-  // Remove códigos específicos no final da descrição (como SCY765/02)
+  // Remove specific codes at the end of the description (e.g., SCY765/02)
   const nameWithoutCode = description.replace(/\s+\w+\/\d+$/, '');
-  
-  // Capitaliza cada palavra
+
+  // Capitalize each word
   return nameWithoutCode
     .split(' ')
     .map(word => {
-      // Não capitaliza palavras pequenas como "de", "da", "do", etc.
+      // Do not capitalize small words like "de", "da", "do", etc.
       const smallWords = ['de', 'da', 'do', 'das', 'dos', 'e', 'com', 'em', 'para'];
       if (smallWords.includes(word.toLowerCase())) {
         return word.toLowerCase();
@@ -22,29 +22,29 @@ const formatProductDescription = (description: string): string => {
 export const generateProductDescription = (product: Product): string => {
   const parts: string[] = [];
   
-  // Nome do produto formatado
+  // Formatted product name
   const formattedDescription = formatProductDescription(product.description);
   parts.push(formattedDescription);
 
-  // Dados técnicos em uma seção separada
+  // Technical data in a separate section
   const technicalInfo: string[] = [];
 
-  // Adiciona referência se disponível (sem o prefixo REF)
+  // Add reference if available (without the REF prefix)
   if (product.reference) {
     technicalInfo.push(product.reference);
   }
 
-  // Adiciona código do produto se disponível e diferente da referência
+  // Add product code if available and different from the reference
   if (product.code && product.code !== product.reference) {
     technicalInfo.push(product.code);
   }
 
-  // Adiciona EAN se disponível (sem o prefixo EAN)
+  // Add EAN if available (without the EAN prefix)
   if (product.ean) {
     technicalInfo.push(product.ean);
   }
 
-  // Informações de cor e tamanho
+  // Color and size information
   const attributes: string[] = [];
   
   if (product.color) {
@@ -55,7 +55,7 @@ export const generateProductDescription = (product: Product): string => {
     attributes.push(`TAM: ${product.size}`);
   }
 
-  // Monta a descrição final
+  // Build the final description
   if (attributes.length > 0) {
     parts.push(attributes.join(' '));
   }
@@ -64,6 +64,6 @@ export const generateProductDescription = (product: Product): string => {
     parts.push(technicalInfo.join(' '));
   }
 
-  // Une todas as partes usando apenas espaço como separador
+  // Join all parts using a single space as separator
   return parts.join(' ');
 };

--- a/src/utils/sizeParser.ts
+++ b/src/utils/sizeParser.ts
@@ -9,40 +9,40 @@ const sizePatterns: SizePattern[] = [
   {
     pattern: /\b(PP|P|M|G|GG|XG|XXG)\b/i,
     sizes: ['PP', 'P', 'M', 'G', 'GG', 'XG', 'XXG'],
-    description: 'Tamanhos padrão de vestuário'
+    description: 'Standard clothing sizes'
   },
   {
     pattern: /\b(\d{2}\/\d{2})\b/,
-    sizes: [], // Dinâmico, ex: "34/35"
-    description: 'Tamanhos de calçados com faixa'
+    sizes: [], // Dynamic, e.g., "34/35"
+    description: 'Shoe sizes with range'
   },
   {
     pattern: /\bTAM(?:ANHO)?[\s:.]-?\s*([A-Za-z0-9]{1,3})\b/i,
-    sizes: [], // Dinâmico, ex: "TAM: G" ou "TAMANHO M"
-    description: 'Indicador explícito de tamanho'
+    sizes: [], // Dynamic, e.g., "TAM: G" or "TAMANHO M"
+    description: 'Explicit size indicator'
   },
   {
     pattern: /\b(INFANTIL|ADULTO|JUVENIL)\b/i,
     sizes: ['INFANTIL', 'ADULTO', 'JUVENIL'],
-    description: 'Categorias de tamanho'
+    description: 'Size categories'
   },
   {
     pattern: /-(\d{1,2})(?:\s|$)/,
-    sizes: [], // Dinâmico, números no final da referência
-    description: 'Números no final da referência (estilo Kelly)'
+    sizes: [], // Dynamic, numbers at the end of the reference
+    description: 'Numbers at the end of the reference (Kelly style)'
   },
   {
     pattern: /(?:FEMININA|MASCULINA|INFANTIL)-(\d{1,2})-/i,
-    sizes: [], // Dinâmico, padrão Elian: IG FEMININA-12-2037
-    description: 'Padrão Elian (número entre hífens)'
+    sizes: [], // Dynamic, Elian pattern: IG FEMININA-12-2037
+    description: 'Elian pattern (number between hyphens)'
   }
 ];
 
-const normalizarTamanho = (tamanho: string): string => {
-  const normalizado = tamanho.trim().toUpperCase();
-  
-  // Padroniza nomenclaturas específicas
-  const padronizacoes: { [key: string]: string } = {
+const normalizeSize = (size: string): string => {
+  const normalized = size.trim().toUpperCase();
+
+  // Standardize specific nomenclatures
+  const standardizations: { [key: string]: string } = {
     'PEQUENO': 'P',
     'MEDIO': 'M',
     'MÉDIO': 'M',
@@ -51,34 +51,34 @@ const normalizarTamanho = (tamanho: string): string => {
     'EXTRA PEQUENO': 'PP'
   };
 
-  return padronizacoes[normalizado] || normalizado;
+  return standardizations[normalized] || normalized;
 };
 
-const validarTamanho = (tamanho: string): boolean => {
-  const tamanhosValidos = new Set([
+const validateSize = (size: string): boolean => {
+  const validSizes = new Set([
     'PP', 'P', 'M', 'G', 'GG', 'XG', 'XXG',
     'INFANTIL', 'ADULTO', 'JUVENIL'
   ]);
 
-  const padraoNumerico = /^\d{1,2}$/;  // 1 ou 2 dígitos
-  const padraoFaixa = /^\d{2}\/\d{2}$/;  // formato 00/00
+  const numericPattern = /^\d{1,2}$/;  // 1 or 2 digits
+  const rangePattern = /^\d{2}\/\d{2}$/;  // format 00/00
 
-  const tamanhoNormalizado = normalizarTamanho(tamanho);
+  const normalizedSize = normalizeSize(size);
 
-  return tamanhosValidos.has(tamanhoNormalizado) ||
-         padraoNumerico.test(tamanhoNormalizado) ||
-         padraoFaixa.test(tamanhoNormalizado);
+  return validSizes.has(normalizedSize) ||
+         numericPattern.test(normalizedSize) ||
+         rangePattern.test(normalizedSize);
 };
 
-export const extrairTamanhoDaReferencia = (referencia: string): string => {
-  if (!referencia) return '';
+export const extractSizeFromReference = (reference: string): string => {
+  if (!reference) return '';
 
-  // Procura por número no final da referência (estilo Kelly)
-  const match = referencia.match(/-(\d{1,2})(?:\s|$)/);
+  // Search for a number at the end of the reference (Kelly style)
+  const match = reference.match(/-(\d{1,2})(?:\s|$)/);
   if (match && match[1]) {
-    const tamanho = match[1];
-    if (validarTamanho(tamanho)) {
-      return tamanho;
+    const size = match[1];
+    if (validateSize(size)) {
+      return size;
     }
   }
 
@@ -88,29 +88,29 @@ export const extrairTamanhoDaReferencia = (referencia: string): string => {
 export const extractSizeFromDescription = (description: string): string => {
   if (!description) return '';
 
-  const textoNormalizado = description.toUpperCase();
-  
-  // Padrão Elian: extrai número entre hífens após FEMININA/MASCULINA/INFANTIL
-  const matchElian = textoNormalizado.match(/(?:FEMININA|MASCULINA|INFANTIL)-(\d{1,2})-/i);
-  if (matchElian && matchElian[1]) {
-    const tamanho = matchElian[1];
-    if (validarTamanho(tamanho)) {
-      return tamanho;
+  const normalizedText = description.toUpperCase();
+
+  // Elian pattern: extract number between hyphens after FEMININA/MASCULINA/INFANTIL
+  const elianMatch = normalizedText.match(/(?:FEMININA|MASCULINA|INFANTIL)-(\d{1,2})-/i);
+  if (elianMatch && elianMatch[1]) {
+    const size = elianMatch[1];
+    if (validateSize(size)) {
+      return size;
     }
   }
 
-  // Casos especiais para produtos infantis
-  if (textoNormalizado.includes('INFAN') && textoNormalizado.includes('COMUM')) {
+  // Special cases for children's products
+  if (normalizedText.includes('INFAN') && normalizedText.includes('COMUM')) {
     return 'INFANTIL';
   }
 
-  // Outros padrões de tamanho
+  // Other size patterns
   for (const { pattern } of sizePatterns) {
-    const match = textoNormalizado.match(pattern);
+    const match = normalizedText.match(pattern);
     if (match && match[1]) {
-      const tamanhoEncontrado = normalizarTamanho(match[1]);
-      if (validarTamanho(tamanhoEncontrado)) {
-        return tamanhoEncontrado;
+      const foundSize = normalizeSize(match[1]);
+      if (validateSize(foundSize)) {
+        return foundSize;
       }
     }
   }
@@ -118,49 +118,49 @@ export const extractSizeFromDescription = (description: string): string => {
   return '';
 };
 
-// Função para debug e análise de padrões
+// Function for debugging and pattern analysis
 export const analyzeDetailedPatterns = (description: string): {
-  tamanhoEncontrado: string;
-  padraoUtilizado?: string;
-  detalhes: string[];
+  foundSize: string;
+  usedPattern?: string;
+  details: string[];
 } => {
-  const detalhes: string[] = [];
-  
+  const details: string[] = [];
+
   if (!description) {
-    return { 
-      tamanhoEncontrado: '', 
-      detalhes: ['Descrição vazia']
+    return {
+      foundSize: '',
+      details: ['Empty description']
     };
   }
 
-  const textoNormalizado = description.toUpperCase();
-  detalhes.push(`Texto normalizado: ${textoNormalizado}`);
+  const normalizedText = description.toUpperCase();
+  details.push(`Normalized text: ${normalizedText}`);
 
   for (const { pattern, description } of sizePatterns) {
-    const match = textoNormalizado.match(pattern);
+    const match = normalizedText.match(pattern);
     if (match) {
-      detalhes.push(`Padrão encontrado: ${description}`);
-      detalhes.push(`Match completo: ${match[0]}`);
-      
+      details.push(`Pattern found: ${description}`);
+      details.push(`Full match: ${match[0]}`);
+
       if (match[1]) {
-        const tamanhoNormalizado = normalizarTamanho(match[1]);
-        detalhes.push(`Tamanho normalizado: ${tamanhoNormalizado}`);
-        
-        if (validarTamanho(tamanhoNormalizado)) {
+        const normalizedSize = normalizeSize(match[1]);
+        details.push(`Normalized size: ${normalizedSize}`);
+
+        if (validateSize(normalizedSize)) {
           return {
-            tamanhoEncontrado: tamanhoNormalizado,
-            padraoUtilizado: description,
-            detalhes
+            foundSize: normalizedSize,
+            usedPattern: description,
+            details
           };
         } else {
-          detalhes.push(`Tamanho "${tamanhoNormalizado}" não passou na validação`);
+          details.push(`Size "${normalizedSize}" failed validation`);
         }
       }
     }
   }
 
   return {
-    tamanhoEncontrado: '',
-    detalhes: [...detalhes, 'Nenhum tamanho válido encontrado']
+    foundSize: '',
+    details: [...details, 'No valid size found']
   };
 };


### PR DESCRIPTION
## Summary
- rename size parsing functions to `extractSizeFromReference` and `extractSizeFromDescription`
- translate variable names, comments, and log messages to English
- update components and XML parser to use new identifiers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0bbd78208325aa70fc78597af72c