### PR TITLE
chore: use pt-BR locale for number formatting

### DIFF
--- a/lixo/src/components/product-preview/types/column.ts
+++ b/lixo/src/components/product-preview/types/column.ts
@@ -101,10 +101,10 @@ export const getDefaultColumns = (): Column[] => [
     width: 'w-fit',
     minWidth: 80,
     order: 10,
-    format: (value: number) => value.toLocaleString()
+    format: (value: number) => value.toLocaleString('pt-BR')
   },
-  { 
-    id: 'unitPrice', 
+  {
+    id: 'unitPrice',
     header: 'Custo Bruto', 
     initiallyVisible: true, 
     alignment: 'right',

--- a/lixo/src/components/ui/chart.tsx
+++ b/lixo/src/components/ui/chart.tsx
@@ -238,7 +238,7 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {item.value.toLocaleString('pt-BR')}
                         </span>
                       )}
                     </div>

--- a/src/components/product-preview/types/column.ts
+++ b/src/components/product-preview/types/column.ts
@@ -101,10 +101,10 @@ export const getDefaultColumns = (): Column[] => [
     width: 'w-fit',
     minWidth: 80,
     order: 10,
-    format: (value: number) => value.toLocaleString()
+    format: (value: number) => value.toLocaleString('pt-BR')
   },
-  { 
-    id: 'unitPrice', 
+  {
+    id: 'unitPrice',
     header: 'Custo Bruto', 
     initiallyVisible: true, 
     alignment: 'right',

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -238,7 +238,7 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {item.value.toLocaleString('pt-BR')}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- ensure chart tooltips format numbers using pt-BR locale
- apply pt-BR locale to quantity column formatter across codebase

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba10d07130832587058bc59c77f77e